### PR TITLE
Add pytest test suite for core modules (#526)

### DIFF
--- a/tests/test_bounty_index.py
+++ b/tests/test_bounty_index.py
@@ -1,0 +1,103 @@
+"""Tests for bounty index and RTC parsing."""
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+from concierge.bounty_index import parse_reward, estimate_difficulty, tag_skills
+
+
+class TestParseReward:
+    """Test RTC amount parsing from issue titles and bodies."""
+
+    def test_parse_rtc_from_title_simple(self):
+        """Test parsing simple RTC amount from title."""
+        title = "[Bounty: 10 RTC] Add new feature"
+        result = parse_reward(title, "")
+        assert result == 10.0
+
+    def test_parse_rtc_from_body(self):
+        """Test parsing RTC from body when not in title."""
+        title = "Feature request"
+        body = "Reward: 50 RTC for completion"
+        result = parse_reward(title, body)
+        assert result == 50.0
+
+    def test_parse_rtc_no_match_returns_zero(self):
+        """Test title and body without RTC returns 0."""
+        result = parse_reward("Just a regular issue", "No reward here")
+        assert result == 0.0
+
+    def test_parse_rtc_case_insensitive(self):
+        """Test RTC parsing is case insensitive."""
+        result1 = parse_reward("[Bounty: 20 rtc] Task", "")
+        result2 = parse_reward("[Bounty: 20 RTC] Task", "")
+        assert result1 == result2 == 20.0
+
+    def test_parse_rtc_decimal(self):
+        """Test parsing decimal RTC amount."""
+        result = parse_reward("[Bounty: 15.5 RTC] Task", "")
+        assert result == 15.5
+
+    def test_parse_rtc_with_comma(self):
+        """Test parsing RTC with comma formatting."""
+        result = parse_reward("[Bounty: 1,000 RTC] Large task", "")
+        assert result == 1000.0
+
+
+class TestEstimateDifficulty:
+    """Test difficulty estimation."""
+
+    def test_difficulty_micro(self):
+        """Test micro difficulty for small rewards."""
+        result = estimate_difficulty("Some task", [], 5)
+        assert result == "micro"
+
+    def test_difficulty_standard(self):
+        """Test standard difficulty."""
+        result = estimate_difficulty("Task", [], 25)
+        assert result == "standard"
+
+    def test_difficulty_major(self):
+        """Test major difficulty."""
+        result = estimate_difficulty("Big task", [], 100)
+        assert result == "major"
+
+    def test_difficulty_critical(self):
+        """Test critical difficulty."""
+        result = estimate_difficulty("Huge task", [], 250)
+        assert result == "critical"
+
+    def test_difficulty_label_overrides_reward(self):
+        """Test difficulty label overrides reward calculation."""
+        result = estimate_difficulty("Task", ["critical"], 5)
+        assert result == "critical"
+
+
+class TestTagSkills:
+    """Test skill tagging."""
+
+    def test_tag_python(self):
+        """Test Python skill detection."""
+        result = tag_skills("Fix Python script", "")
+        assert "python" in result
+
+    def test_tag_rust(self):
+        """Test Rust skill detection."""
+        result = tag_skills("Rust implementation needed", "")
+        assert "rust" in result
+
+    def test_tag_docker(self):
+        """Test Docker skill detection."""
+        result = tag_skills("Add Dockerfile", "")
+        assert "docker" in result
+
+    def test_tag_multiple_skills(self):
+        """Test multiple skill detection."""
+        result = tag_skills("Python and Docker project", "")
+        assert "python" in result
+        assert "docker" in result
+
+    def test_no_skills_returns_empty(self):
+        """Test no matching skills returns empty list."""
+        result = tag_skills("Just some text", "")
+        assert result == []

--- a/tests/test_faq_engine.py
+++ b/tests/test_faq_engine.py
@@ -1,0 +1,38 @@
+"""Tests for FAQ engine."""
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+from concierge.faq_engine import FAQ_ENTRIES
+
+
+class TestFAQEntries:
+    """Test FAQ entries data."""
+
+    def test_faq_entries_not_empty(self):
+        """Test FAQ_ENTRIES is not empty."""
+        assert len(FAQ_ENTRIES) > 0
+
+    def test_all_faq_entries_have_content(self):
+        """Test all FAQ entries have non-empty content."""
+        for key, value in FAQ_ENTRIES.items():
+            assert key.strip() != ""
+            assert value.strip() != ""
+            assert len(value) > 10
+
+    def test_rtc_faq_entry_exists(self):
+        """Test RTC explanation FAQ exists."""
+        assert "what is rtc" in FAQ_ENTRIES
+        assert "RustChain Token" in FAQ_ENTRIES["what is rtc"]
+
+    def test_wallet_setup_faq_exists(self):
+        """Test wallet setup FAQ exists."""
+        assert "how do i set up a wallet" in FAQ_ENTRIES
+
+    def test_payout_faq_exists(self):
+        """Test payout FAQ exists."""
+        assert "how do payouts work" in FAQ_ENTRIES
+
+    def test_poa_faq_exists(self):
+        """Test Proof of Antiquity FAQ exists."""
+        assert "what is proof of antiquity" in FAQ_ENTRIES

--- a/tests/test_wallet_helper.py
+++ b/tests/test_wallet_helper.py
@@ -1,0 +1,118 @@
+"""Tests for wallet helper functions."""
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+from concierge.wallet_helper import validate_wallet_name
+
+
+class TestValidateWalletName:
+    """Test wallet name validation."""
+
+    def test_valid_simple_name(self):
+        """Test simple valid wallet name."""
+        is_valid, msg = validate_wallet_name("my-wallet")
+        assert is_valid is True
+        assert "Valid" in msg
+
+    def test_valid_name_with_numbers(self):
+        """Test valid name with numbers."""
+        is_valid, _ = validate_wallet_name("wallet123")
+        assert is_valid is True
+
+    def test_valid_name_alphanumeric(self):
+        """Test valid alphanumeric name."""
+        is_valid, _ = validate_wallet_name("abc123xyz")
+        assert is_valid is True
+
+    def test_invalid_too_short(self):
+        """Test name too short is invalid."""
+        is_valid, msg = validate_wallet_name("ab")
+        assert is_valid is False
+        assert "at least 3 characters" in msg
+
+    def test_invalid_too_long(self):
+        """Test name too long is invalid."""
+        long_name = "a" * 65
+        is_valid, msg = validate_wallet_name(long_name)
+        assert is_valid is False
+        assert "64 characters" in msg
+
+    def test_invalid_starts_with_hyphen(self):
+        """Test name starting with hyphen is invalid."""
+        is_valid, _ = validate_wallet_name("-wallet")
+        assert is_valid is False
+
+    def test_invalid_ends_with_hyphen(self):
+        """Test name ending with hyphen is invalid."""
+        is_valid, _ = validate_wallet_name("wallet-")
+        assert is_valid is False
+
+    def test_invalid_uppercase(self):
+        """Test uppercase letters are invalid."""
+        is_valid, msg = validate_wallet_name("MyWallet")
+        assert is_valid is False
+        assert "lowercase" in msg
+
+    def test_invalid_special_chars(self):
+        """Test special characters are invalid."""
+        is_valid, _ = validate_wallet_name("wallet@123")
+        assert is_valid is False
+
+    def test_valid_with_hyphens(self):
+        """Test valid name with hyphens in middle."""
+        is_valid, _ = validate_wallet_name("my-test-wallet")
+        assert is_valid is True
+
+    def test_valid_minimum_length(self):
+        """Test minimum valid length (3 chars)."""
+        is_valid, _ = validate_wallet_name("abc")
+        assert is_valid is True
+
+    def test_valid_maximum_length(self):
+        """Test maximum valid length (64 chars)."""
+        name = "a" + "b" * 62 + "c"
+        is_valid, _ = validate_wallet_name(name)
+        assert is_valid is True
+
+    def test_empty_name_invalid(self):
+        """Test empty name is invalid."""
+        is_valid, msg = validate_wallet_name("")
+        assert is_valid is False
+        assert "cannot be empty" in msg
+
+    def test_none_name_invalid(self):
+        """Test None name is invalid."""
+        is_valid, _ = validate_wallet_name(None)
+        assert is_valid is False
+
+
+class TestWalletHelpersIntegration:
+    """Integration tests for wallet helpers."""
+
+    def test_wallet_name_validation_comprehensive(self):
+        """Test comprehensive wallet name validation."""
+        valid_names = [
+            "test-wallet",
+            "mywallet",
+            "wallet123",
+            "abc",
+            "a-b-c",
+        ]
+        
+        invalid_names = [
+            "ab",  # too short
+            "-wallet",  # starts with hyphen
+            "wallet-",  # ends with hyphen
+            "MyWallet",  # uppercase
+            "wallet@",  # special char
+            "wallet_name",  # underscore
+        ]
+        
+        for name in valid_names:
+            is_valid, _ = validate_wallet_name(name)
+            assert is_valid is True, f"{name} should be valid"
+        
+        for name in invalid_names:
+            is_valid, _ = validate_wallet_name(name)
+            assert is_valid is False, f"{name} should be invalid"


### PR DESCRIPTION
This PR adds a comprehensive pytest test suite covering the core concierge modules as requested in #526.

## Changes

### Test Files Added
- `tests/test_faq_engine.py` - Tests for FAQ entries data
- `tests/test_bounty_index.py` - Tests for RTC parsing, difficulty estimation, and skill tagging
- `tests/test_wallet_helper.py` - Tests for wallet name validation

### Test Coverage
- **37 tests total**, all passing
- FAQ entries validation
- RTC amount parsing from titles and bodies
- Difficulty estimation based on reward size and labels
- Skill tagging from keywords
- Wallet name validation (length, characters, format)

### Running Tests
```bash
pytest tests/ -v
```

All tests pass successfully.

## Wallet for Payout
RTCd3611f1c031a08513db65a8e0087e82be4c8fc95

Closes #526