### PR TITLE
Fix: Remove unsupported show and repos commands from README quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,11 +109,14 @@ concierge wallet balance my-wallet-name
 # Claim a bounty
 concierge claim 491 --wallet my-wallet-name --approach "I will fuzz the fleet detector"
 
-# Show bounty details
-concierge show 501
+# Check concierge status
+concierge status
 
-# List ecosystem repos
-concierge repos
+# View FAQ / helper docs
+concierge faq
+
+# Check installed version
+concierge version
 ```
 
 ---


### PR DESCRIPTION
## What this PR fixes\nFixes #13 by correcting README quickstart examples that currently fail with \'invalid choice\'.\n\n## Changes\n- Removed unsupported commands:\n  - `concierge show 501`\n  - `concierge repos`\n- Replaced with supported commands:\n  - `concierge status`\n  - `concierge faq`\n  - `concierge version`\n\n## Scope\n- Docs-only change (`README.md`)\n- No runtime code changes\n