### PR TITLE
ci: add Dependabot for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` to automate dependency updates
- Monitors **pip** and **GitHub Actions** ecosystems
- Weekly schedule with `dependencies` label for easy tracking

## Bounty
Addresses bounty [#1613](https://github.com/Scottcjn/rustchain-bounties/issues/1613) — Dependabot setup for Elyan Labs repos.

Wallet for payout: wirework