### PR TITLE
test: extend faq_engine and bounty_index test suites (+54 tests)

### DIFF
--- a/tests/test_bounty_index.py
+++ b/tests/test_bounty_index.py
@@ -67,45 +67,113 @@ class TestParseReward:
         reward = bounty_index.parse_reward(title, "")
         assert reward == 10000.0
 
+    def test_title_takes_priority_over_body(self):
+        """When both title and body have RTC, title value is returned first."""
+        title = "Fix: 8 RTC reward"
+        body = "Additional context: also 50 RTC mentioned here"
+        reward = bounty_index.parse_reward(title, body)
+        assert reward == 8.0
+
+    def test_returns_float(self):
+        """Return value should always be a float."""
+        reward = bounty_index.parse_reward("10 RTC bounty", "")
+        assert isinstance(reward, float)
+
+    def test_returns_zero_float_when_no_match(self):
+        """Should return 0.0 (float) when no RTC found."""
+        reward = bounty_index.parse_reward("no reward here", "")
+        assert reward == 0.0
+        assert isinstance(reward, float)
+
+    def test_rtc_not_matched_as_substring(self):
+        """'RTC' inside a word (e.g. 'WRTC') should not match."""
+        title = "Add WRTC bridge"
+        reward = bounty_index.parse_reward(title, "")
+        assert reward == 0.0
+
+    def test_empty_title_and_body(self):
+        """Empty title and body should return 0."""
+        assert bounty_index.parse_reward("", "") == 0.0
+
+    def test_rtc_in_body_only(self):
+        """If only body has RTC amount, it should still be found."""
+        reward = bounty_index.parse_reward("", "Reward is 42 RTC for this task")
+        assert reward == 42.0
+
 
 class TestEstimateDifficulty:
-    """Tests for difficulty estimation."""
+    """Tests for difficulty estimation with exact tier assertions."""
 
-    def test_high_reward_high_difficulty(self):
-        """High reward should indicate some difficulty level."""
-        difficulty = bounty_index.estimate_difficulty(
-            "Complex system",
-            [],
-            reward=100
-        )
-        assert difficulty is not None
+    def test_micro_tier_below_10(self):
+        """Reward < 10 RTC should return 'micro'."""
+        assert bounty_index.estimate_difficulty("Task", [], 5) == "micro"
 
-    def test_low_reward_low_difficulty(self):
-        """Low reward should indicate some difficulty level."""
-        difficulty = bounty_index.estimate_difficulty(
-            "Simple fix",
-            [],
-            reward=5
-        )
-        assert difficulty is not None
+    def test_micro_tier_at_zero(self):
+        """Zero reward should return 'micro'."""
+        assert bounty_index.estimate_difficulty("Task", [], 0) == "micro"
 
-    def test_difficulty_labels_override(self):
-        """Labels should influence difficulty."""
-        difficulty = bounty_index.estimate_difficulty(
-            "Anything",
-            ["good first issue"],
-            reward=50
-        )
-        assert difficulty is not None
+    def test_micro_tier_at_nine(self):
+        """9 RTC should return 'micro'."""
+        assert bounty_index.estimate_difficulty("Task", [], 9) == "micro"
 
-    def test_difficulty_with_both_labels(self):
-        """Multiple labels should be considered."""
-        difficulty = bounty_index.estimate_difficulty(
-            "Issue",
-            ["enhancement", "bug"],
-            reward=30
-        )
-        assert difficulty is not None
+    def test_standard_tier_at_10(self):
+        """10 RTC should return 'standard'."""
+        assert bounty_index.estimate_difficulty("Task", [], 10) == "standard"
+
+    def test_standard_tier_at_50(self):
+        """50 RTC should return 'major' (boundary >= 50 is major)."""
+        result = bounty_index.estimate_difficulty("Task", [], 50)
+        assert result == "major"
+
+    def test_standard_tier_midrange(self):
+        """30 RTC should return 'standard'."""
+        assert bounty_index.estimate_difficulty("Task", [], 30) == "standard"
+
+    def test_major_tier_at_100(self):
+        """100 RTC should return 'major'."""
+        assert bounty_index.estimate_difficulty("Task", [], 100) == "major"
+
+    def test_major_tier_at_199(self):
+        """199 RTC should return 'major'."""
+        assert bounty_index.estimate_difficulty("Task", [], 199) == "major"
+
+    def test_critical_tier_at_200(self):
+        """200 RTC should return 'critical'."""
+        assert bounty_index.estimate_difficulty("Task", [], 200) == "critical"
+
+    def test_critical_tier_large(self):
+        """1000 RTC should return 'critical'."""
+        assert bounty_index.estimate_difficulty("Task", [], 1000) == "critical"
+
+    def test_label_critical_overrides_low_reward(self):
+        """'critical' label should override reward-based estimate."""
+        result = bounty_index.estimate_difficulty("Task", ["critical"], 5)
+        assert result == "critical"
+
+    def test_label_major_overrides_low_reward(self):
+        """'major' label should override low reward."""
+        result = bounty_index.estimate_difficulty("Task", ["major"], 3)
+        assert result == "major"
+
+    def test_label_standard_overrides(self):
+        """'standard' label should override critical reward."""
+        result = bounty_index.estimate_difficulty("Task", ["standard"], 500)
+        assert result == "standard"
+
+    def test_label_micro_overrides_high_reward(self):
+        """'micro' label should override high reward."""
+        result = bounty_index.estimate_difficulty("Task", ["micro"], 300)
+        assert result == "micro"
+
+    def test_labels_case_insensitive(self):
+        """Labels should be compared case-insensitively."""
+        result = bounty_index.estimate_difficulty("Task", ["CRITICAL"], 5)
+        assert result == "critical"
+
+    def test_unknown_labels_fall_back_to_reward(self):
+        """Unknown labels should not affect reward-based estimate."""
+        result = bounty_index.estimate_difficulty("Task", ["enhancement", "bug"], 75)
+        assert result == "major"
 
 
 class TestTagSkills:
@@ -135,6 +203,51 @@ class TestTagSkills:
         """No specific skills should return empty or minimal tags."""
         tags = bounty_index.tag_skills("General task", "")
         assert isinstance(tags, list)
+
+    def test_docker_tag_from_body(self):
+        """Docker keyword in body should tag docker."""
+        tags = bounty_index.tag_skills("Deploy service", "Use Docker and docker-compose")
+        assert "docker" in tags
+
+    def test_security_tag(self):
+        """Security keyword should tag security."""
+        tags = bounty_index.tag_skills("Security audit needed", "")
+        assert "security" in tags
+
+    def test_documentation_tag(self):
+        """Documentation keyword should tag documentation."""
+        tags = bounty_index.tag_skills("Update documentation", "")
+        assert "documentation" in tags
+
+    def test_ci_cd_tag(self):
+        """CI/CD keyword should tag ci/cd."""
+        tags = bounty_index.tag_skills("Set up CI/CD pipeline", "")
+        assert "ci/cd" in tags
+
+    def test_translation_tag(self):
+        """Translation keyword should tag translation."""
+        tags = bounty_index.tag_skills("Add translation for Spanish", "")
+        assert "translation" in tags
+
+    def test_tags_are_sorted(self):
+        """Returned tags should be sorted alphabetically."""
+        tags = bounty_index.tag_skills("Python Docker security", "rust cargo")
+        assert tags == sorted(tags)
+
+    def test_no_duplicate_tags(self):
+        """Each skill should appear at most once."""
+        tags = bounty_index.tag_skills("python .py flask django pip", "")
+        assert len(tags) == len(set(tags))
+
+    def test_nodejs_triggers_javascript_tag(self):
+        """'node' keyword should tag javascript."""
+        tags = bounty_index.tag_skills("Build node.js backend", "")
+        assert "javascript" in tags
+
+    def test_social_media_tag(self):
+        """Social media keyword should tag social-media."""
+        tags = bounty_index.tag_skills("Post on Twitter and Moltbook", "")
+        assert "social-media" in tags
 
 
 class TestFormatMarkdown:
@@ -170,6 +283,68 @@ class TestFormatMarkdown:
         result = bounty_index.format_markdown([])
         assert isinstance(result, str)
 
+    def test_format_includes_header_row(self):
+        """Output should include a markdown table header."""
+        result = bounty_index.format_markdown([])
+        assert "|" in result
+        # Header row expected
+        assert "Repo" in result or "Title" in result or "RTC" in result
+
+    def test_format_bounty_with_skills(self):
+        """Skills should appear in the formatted output."""
+        bounties = [{
+            "title": "Python task",
+            "reward_rtc": 15,
+            "number": 42,
+            "repo": "org/repo",
+            "skills": ["python", "docker"],
+            "difficulty": "standard"
+        }]
+        result = bounty_index.format_markdown(bounties)
+        assert "python" in result
+        assert "docker" in result
+
+    def test_format_long_title_truncated(self):
+        """Titles longer than 60 chars should be truncated."""
+        long_title = "A" * 80
+        bounties = [{
+            "title": long_title,
+            "reward_rtc": 5,
+            "number": 1,
+            "repo": "a/b",
+            "skills": [],
+            "difficulty": "micro"
+        }]
+        result = bounty_index.format_markdown(bounties)
+        # Title in output should not be 80 chars (truncated to 60)
+        assert long_title not in result
+
+    def test_format_repo_shows_short_name(self):
+        """Should display short repo name (after slash)."""
+        bounties = [{
+            "title": "Task",
+            "reward_rtc": 10,
+            "number": 1,
+            "repo": "myorg/myrepo",
+            "skills": [],
+            "difficulty": "standard"
+        }]
+        result = bounty_index.format_markdown(bounties)
+        assert "myrepo" in result
+
+    def test_format_reward_shown_as_float(self):
+        """Reward should be formatted as a float."""
+        bounties = [{
+            "title": "Task",
+            "reward_rtc": 7,
+            "number": 1,
+            "repo": "a/b",
+            "skills": [],
+            "difficulty": "micro"
+        }]
+        result = bounty_index.format_markdown(bounties)
+        assert "7.0" in result
+
 
 class TestFetchBountiesIntegration:
     """Integration tests for fetch_bounties with mocked GitHub API."""
@@ -185,7 +360,6 @@ class TestFetchBountiesIntegration:
                 pass
 
             def json(self):
-                # Issues endpoint can include PRs with pull_request key
                 return [
                     {"number": 1, "title": "[Bounty: 10 RTC] Issue", "body": "",
                      "html_url": "https://github.com/a/b/issues/1",
@@ -196,14 +370,181 @@ class TestFetchBountiesIntegration:
                      "pull_request": {"url": "https://api.github.com/repos/a/b/pulls/2"}},
                 ]
 
-        monkeypatch.setattr(
-            requests, "get",
-            lambda *a, **kw: MockResponse()
-        )
+        monkeypatch.setattr(requests, "get", lambda *a, **kw: MockResponse())
         monkeypatch.setattr(bounty_index, "GITHUB_TOKEN", None)
         monkeypatch.setattr(bounty_index, "REPOS", ["a/b"])
 
         bounties = bounty_index.fetch_bounties()
-        # Should only return the issue, not the PR
         assert len(bounties) == 1
         assert bounties[0]["number"] == 1
+
+    def test_fetch_enriches_with_reward_and_difficulty(self, monkeypatch):
+        """Returned bounties should have reward_rtc, difficulty, and skills fields."""
+        import requests
+
+        class MockResponse:
+            status_code = 200
+
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return [{
+                    "number": 5,
+                    "title": "[Bounty: 50 RTC] Python script",
+                    "body": "Write a python script",
+                    "html_url": "https://github.com/a/b/issues/5",
+                    "labels": [{"name": "bounty"}],
+                    "created_at": "2026-01-01T00:00:00Z",
+                }]
+
+        monkeypatch.setattr(requests, "get", lambda *a, **kw: MockResponse())
+        monkeypatch.setattr(bounty_index, "GITHUB_TOKEN", None)
+        monkeypatch.setattr(bounty_index, "REPOS", ["a/b"])
+
+        bounties = bounty_index.fetch_bounties()
+        assert len(bounties) == 1
+        b = bounties[0]
+        assert b["reward_rtc"] == 50.0
+        assert b["difficulty"] == "major"
+        assert "python" in b["skills"]
+
+    def test_fetch_handles_404_gracefully(self, monkeypatch):
+        """404 response should be silently skipped, not raise."""
+        import requests
+
+        class MockResponse404:
+            status_code = 404
+
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return []
+
+        monkeypatch.setattr(requests, "get", lambda *a, **kw: MockResponse404())
+        monkeypatch.setattr(bounty_index, "GITHUB_TOKEN", None)
+        monkeypatch.setattr(bounty_index, "REPOS", ["nonexistent/repo"])
+
+        bounties = bounty_index.fetch_bounties()
+        assert bounties == []
+
+    def test_fetch_handles_network_error_gracefully(self, monkeypatch):
+        """Network errors should be caught and return empty list."""
+        import requests
+
+        def raise_error(*a, **kw):
+            raise requests.RequestException("network error")
+
+        monkeypatch.setattr(requests, "get", raise_error)
+        monkeypatch.setattr(bounty_index, "GITHUB_TOKEN", None)
+        monkeypatch.setattr(bounty_index, "REPOS", ["a/b"])
+
+        bounties = bounty_index.fetch_bounties()
+        assert bounties == []
+
+    def test_fetch_multiple_repos(self, monkeypatch):
+        """Should aggregate bounties from multiple repos."""
+        import requests
+
+        call_count = {"n": 0}
+
+        class MockResponse:
+            status_code = 200
+
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                call_count["n"] += 1
+                return [{
+                    "number": call_count["n"],
+                    "title": f"[Bounty: {call_count['n'] * 10} RTC] Task {call_count['n']}",
+                    "body": "",
+                    "html_url": f"https://github.com/a/repo{call_count['n']}/issues/{call_count['n']}",
+                    "labels": [{"name": "bounty"}],
+                    "created_at": "2026-01-01T00:00:00Z",
+                }]
+
+        monkeypatch.setattr(requests, "get", lambda *a, **kw: MockResponse())
+        monkeypatch.setattr(bounty_index, "GITHUB_TOKEN", None)
+        monkeypatch.setattr(bounty_index, "REPOS", ["a/repo1", "a/repo2"])
+
+        bounties = bounty_index.fetch_bounties()
+        assert len(bounties) == 2
+
+
+class TestAggregate:
+    """Tests for the aggregate function."""
+
+    def test_aggregate_returns_expected_keys(self, monkeypatch):
+        """Aggregate result should have updated_at, total_count, bounties."""
+        monkeypatch.setattr(bounty_index, "REPOS", [])
+
+        result = bounty_index.aggregate()
+        assert "updated_at" in result
+        assert "total_count" in result
+        assert "bounties" in result
+
+    def test_aggregate_total_count_matches_bounties(self, monkeypatch):
+        """total_count should match the length of bounties list."""
+        import requests
+
+        class MockResponse:
+            status_code = 200
+
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return [
+                    {"number": i, "title": f"[Bounty: {i * 5} RTC] Task {i}",
+                     "body": "", "html_url": f"https://github.com/a/b/issues/{i}",
+                     "labels": [{"name": "bounty"}], "created_at": "2026-01-01T00:00:00Z"}
+                    for i in range(1, 4)
+                ]
+
+        monkeypatch.setattr(requests, "get", lambda *a, **kw: MockResponse())
+        monkeypatch.setattr(bounty_index, "GITHUB_TOKEN", None)
+        monkeypatch.setattr(bounty_index, "REPOS", ["a/b"])
+
+        result = bounty_index.aggregate()
+        assert result["total_count"] == len(result["bounties"])
+
+    def test_aggregate_sorted_by_reward_desc(self, monkeypatch):
+        """Bounties should be sorted by reward_rtc descending."""
+        import requests
+
+        class MockResponse:
+            status_code = 200
+
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return [
+                    {"number": 1, "title": "[Bounty: 10 RTC] Task", "body": "",
+                     "html_url": "url1", "labels": [{"name": "bounty"}], "created_at": ""},
+                    {"number": 2, "title": "[Bounty: 100 RTC] Task", "body": "",
+                     "html_url": "url2", "labels": [{"name": "bounty"}], "created_at": ""},
+                    {"number": 3, "title": "[Bounty: 50 RTC] Task", "body": "",
+                     "html_url": "url3", "labels": [{"name": "bounty"}], "created_at": ""},
+                ]
+
+        monkeypatch.setattr(requests, "get", lambda *a, **kw: MockResponse())
+        monkeypatch.setattr(bounty_index, "GITHUB_TOKEN", None)
+        monkeypatch.setattr(bounty_index, "REPOS", ["a/b"])
+
+        result = bounty_index.aggregate()
+        rewards = [b["reward_rtc"] for b in result["bounties"]]
+        assert rewards == sorted(rewards, reverse=True)
+
+    def test_aggregate_updated_at_is_iso_format(self, monkeypatch):
+        """updated_at should be an ISO-8601 formatted timestamp."""
+        from datetime import datetime
+        monkeypatch.setattr(bounty_index, "REPOS", [])
+
+        result = bounty_index.aggregate()
+        # Should parse without error
+        ts = result["updated_at"]
+        assert "T" in ts  # ISO-8601 contains T between date and time

--- a/tests/test_faq_engine.py
+++ b/tests/test_faq_engine.py
@@ -1,6 +1,8 @@
 """Tests for FAQ engine - matching returns correct answers."""
+import os
 import pathlib
 import sys
+import tempfile
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
@@ -67,6 +69,69 @@ class TestFuzzyMatch:
         key, answer, score = faq_engine.fuzzy_match("what is beacon")
         assert answer is not None
 
+    def test_score_is_float_between_zero_and_one(self):
+        """Score should be a float in [0.0, 1.0]."""
+        _, _, score = faq_engine.fuzzy_match("what is rtc")
+        assert isinstance(score, float)
+        assert 0.0 <= score <= 1.0
+
+    def test_exact_match_score_is_one(self):
+        """An exact key match should return score of 1.0."""
+        _, _, score = faq_engine.fuzzy_match("what is rtc")
+        assert score == 1.0
+
+    def test_no_match_score_is_zero(self):
+        """No match should return score of 0.0."""
+        _, _, score = faq_engine.fuzzy_match("xyzabc123nonexistent")
+        assert score == 0.0
+
+    def test_returns_matched_key(self):
+        """Should return the matched FAQ key, not empty."""
+        key, answer, score = faq_engine.fuzzy_match("what is rtc")
+        assert key == "what is rtc"
+
+    def test_custom_entries_override_defaults(self):
+        """Custom entries dict should be used instead of FAQ_ENTRIES."""
+        custom = {"test question": "custom answer here"}
+        key, answer, score = faq_engine.fuzzy_match("test question", entries=custom)
+        assert answer == "custom answer here"
+        assert score == 1.0
+
+    def test_custom_entries_empty_dict(self):
+        """Empty entries dict returns empty tuple."""
+        key, answer, score = faq_engine.fuzzy_match("anything", entries={})
+        assert key == ""
+        assert answer == ""
+        assert score == 0.0
+
+    def test_rip200_faq(self):
+        """RIP-200 FAQ should mention consensus."""
+        key, answer, score = faq_engine.fuzzy_match("what is rip-200")
+        assert answer != ""
+        assert score > 0.0
+
+    def test_rip201_faq(self):
+        """RIP-201 FAQ should be findable."""
+        key, answer, score = faq_engine.fuzzy_match("what is rip-201")
+        assert answer != ""
+
+    def test_hardware_multipliers_faq(self):
+        """Hardware multipliers FAQ should list multiplier values."""
+        key, answer, score = faq_engine.fuzzy_match("hardware multipliers")
+        assert "2.5x" in answer or "G4" in answer
+
+    def test_empty_question_returns_empty(self):
+        """Empty string question should return empty tuple."""
+        key, answer, score = faq_engine.fuzzy_match("")
+        assert key == ""
+        assert answer == ""
+        assert score == 0.0
+
+    def test_whitespace_only_returns_empty(self):
+        """Whitespace-only question should return empty tuple."""
+        key, answer, score = faq_engine.fuzzy_match("   ")
+        assert score == 0.0
+
 
 class TestNormalise:
     """Tests for text normalization."""
@@ -87,6 +152,86 @@ class TestNormalise:
         normalized = faq_engine._normalise("hello   world")
         assert normalized == "hello world"
 
+    def test_leading_trailing_whitespace_stripped(self):
+        """Leading/trailing whitespace should be stripped."""
+        normalized = faq_engine._normalise("  hello  ")
+        assert normalized == "hello"
+
+    def test_mixed_case_and_punctuation(self):
+        """Mixed case with punctuation should be fully normalized."""
+        normalized = faq_engine._normalise("What is RTC?")
+        assert "what" in normalized
+        assert "rtc" in normalized
+        assert "?" not in normalized
+
+    def test_empty_string(self):
+        """Empty string should normalize to empty string."""
+        normalized = faq_engine._normalise("")
+        assert normalized == ""
+
+    def test_hyphens_replaced(self):
+        """Hyphens should be treated as whitespace."""
+        normalized = faq_engine._normalise("rip-200")
+        # Hyphens are punctuation and get replaced
+        assert "200" in normalized
+
+
+class TestSearchDocs:
+    """Tests for documentation search."""
+
+    def test_returns_empty_for_missing_dir(self):
+        """Should return empty string if docs dir doesn't exist."""
+        result = faq_engine.search_docs("anything", docs_dir="/nonexistent/path")
+        assert result == ""
+
+    def test_returns_empty_for_empty_dir(self, tmp_path):
+        """Should return empty string if docs dir has no .md files."""
+        result = faq_engine.search_docs("anything", docs_dir=str(tmp_path))
+        assert result == ""
+
+    def test_finds_matching_paragraph(self, tmp_path):
+        """Should find a paragraph that matches the question."""
+        doc = tmp_path / "test.md"
+        doc.write_text(
+            "## Introduction\n\nThis is about RustChain tokens.\n\n"
+            "## Other section\n\nUnrelated content here.\n"
+        )
+        result = faq_engine.search_docs("rustchain tokens", docs_dir=str(tmp_path))
+        assert "RustChain" in result or "rustchain" in result.lower()
+
+    def test_ignores_non_md_files(self, tmp_path):
+        """Should ignore non-.md files in the docs dir."""
+        txt_file = tmp_path / "notes.txt"
+        txt_file.write_text("RustChain RTC tokens wallet")
+        result = faq_engine.search_docs("rustchain tokens", docs_dir=str(tmp_path))
+        assert result == ""
+
+    def test_returns_best_matching_paragraph(self, tmp_path):
+        """Should return the paragraph with highest keyword overlap."""
+        doc = tmp_path / "guide.md"
+        doc.write_text(
+            "## Mining\n\nMining requires hardware attestation.\n\n"
+            "## Wallets\n\nWallets store RTC tokens for mining rewards. "
+            "Mining wallet setup is important.\n"
+        )
+        result = faq_engine.search_docs("mining wallet", docs_dir=str(tmp_path))
+        # Best match should be the Wallets paragraph (2 keyword hits)
+        assert result != ""
+
+    def test_returns_empty_for_empty_question(self, tmp_path):
+        """Empty question returns empty string."""
+        doc = tmp_path / "doc.md"
+        doc.write_text("## Section\n\nSome content about RTC.\n")
+        result = faq_engine.search_docs("", docs_dir=str(tmp_path))
+        assert result == ""
+
+    def test_skips_short_paragraphs(self, tmp_path):
+        """Paragraphs shorter than 20 chars should be skipped."""
+        doc = tmp_path / "short.md"
+        doc.write_text("# Title\n\nRTC\n\nThis paragraph is long enough to be returned as a result.\n")
+        result = faq_engine.search_docs("rtc paragraph result", docs_dir=str(tmp_path))
+        assert result != "RTC"  # Short "RTC" para skipped
+
 
 class TestAnswer:
     """Tests for the main answer function."""
@@ -105,6 +250,74 @@ class TestAnswer:
         assert isinstance(result, dict)
         assert "answer" in result
         assert result["source"] in ["faq", "docs", "unknown"]
+
+    def test_answer_has_confidence_field(self):
+        """Answer dict should include confidence field."""
+        result = faq_engine.answer("what is rtc")
+        assert "confidence" in result
+        assert isinstance(result["confidence"], float)
+
+    def test_faq_source_for_known_question(self):
+        """Known question should be answered from FAQ source."""
+        result = faq_engine.answer("what is rtc")
+        assert result["source"] == "faq"
+        assert result["confidence"] >= 0.3
+
+    def test_unknown_question_returns_unknown_source(self):
+        """Completely unknown question without grok returns unknown."""
+        result = faq_engine.answer("xyzzy123abcdef987654", use_grok=False)
+        assert result["source"] == "unknown"
+        assert result["confidence"] == 0.0
+
+    def test_unknown_source_has_fallback_message(self):
+        """Unknown source should include a helpful fallback message."""
+        result = faq_engine.answer("xyzzy123abcdef987654", use_grok=False)
+        assert len(result["answer"]) > 0
+        # Should suggest rephrasing or similar
+        assert result["answer"] != ""
+
+    def test_answer_proof_of_antiquity(self):
+        """PoA question should get faq source."""
+        result = faq_engine.answer("what is proof of antiquity")
+        assert result["source"] == "faq"
+        assert "G4" in result["answer"] or "multiplier" in result["answer"].lower()
+
+    def test_grok_used_when_enabled_and_no_faq_match(self, monkeypatch):
+        """When use_grok=True and no FAQ match, Grok should be called."""
+        import requests
+
+        call_count = {"n": 0}
+
+        class MockResponse:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                call_count["n"] += 1
+                return {"choices": [{"message": {"content": "Grok answer"}}]}
+
+        monkeypatch.setattr(requests, "post", lambda *a, **kw: MockResponse())
+        monkeypatch.setattr(faq_engine, "GROK_API_KEY", "test-key")
+
+        result = faq_engine.answer("xyzzy123abcdef987654", use_grok=True)
+        assert result["source"] == "grok"
+        assert result["answer"] == "Grok answer"
+
+    def test_grok_not_called_when_disabled(self, monkeypatch):
+        """When use_grok=False, Grok should never be called."""
+        import requests
+
+        called = {"flag": False}
+
+        def mock_post(*a, **kw):
+            called["flag"] = True
+            raise AssertionError("Grok should not be called")
+
+        monkeypatch.setattr(requests, "post", mock_post)
+        monkeypatch.setattr(faq_engine, "GROK_API_KEY", "test-key")
+
+        faq_engine.answer("xyzzy123abcdef987654", use_grok=False)
+        assert not called["flag"]
 
 
 class TestGrokApiMocking:
@@ -129,7 +342,6 @@ class TestGrokApiMocking:
             requests, "post",
             lambda *a, **kw: MockResponse()
         )
-        # Patch the module-level GROK_API_KEY
         monkeypatch.setattr(faq_engine, "GROK_API_KEY", "test-key")
 
         result = faq_engine.ask_grok("test question")
@@ -150,4 +362,55 @@ class TestGrokApiMocking:
         monkeypatch.setattr(faq_engine, "GROK_API_KEY", "test-key")
 
         result = faq_engine.ask_grok("test question")
+        assert "[error]" in result
+
+    def test_grok_no_api_key_returns_error(self, monkeypatch):
+        """ask_grok without API key should return error message."""
+        monkeypatch.setattr(faq_engine, "GROK_API_KEY", "")
+        result = faq_engine.ask_grok("what is rtc")
+        assert "[error]" in result
+
+    def test_grok_includes_context_in_request(self, monkeypatch):
+        """ask_grok with context should include it in the payload."""
+        import requests
+
+        captured = {}
+
+        class MockResponse:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {"choices": [{"message": {"content": "ok"}}]}
+
+        def mock_post(url, headers, json, timeout):
+            captured["payload"] = json
+            return MockResponse()
+
+        monkeypatch.setattr(requests, "post", mock_post)
+        monkeypatch.setattr(faq_engine, "GROK_API_KEY", "test-key")
+
+        faq_engine.ask_grok("my question", context="some context")
+        user_msg = captured["payload"]["messages"][-1]["content"]
+        assert "some context" in user_msg
+        assert "my question" in user_msg
+
+    def test_grok_unexpected_response_format(self, monkeypatch):
+        """Unexpected Grok response format should return error string."""
+        import requests
+
+        class MockResponse:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {"unexpected": "format"}
+
+        monkeypatch.setattr(
+            requests, "post",
+            lambda *a, **kw: MockResponse()
+        )
+        monkeypatch.setattr(faq_engine, "GROK_API_KEY", "test-key")
+
+        result = faq_engine.ask_grok("question")
         assert "[error]" in result


### PR DESCRIPTION
Follow-up to PR #17 (test_wallet_helper) — adds coverage for the two remaining modules from bounty #526.

## test_faq_engine.py: 17 → 38 tests (+21)
New: TestSearchDocs (7 tests), extended TestFuzzyMatch (score bounds, custom entries, empty inputs), extended TestAnswer (confidence field, grok mock), TestGrokApiMocking (no-key error, context injection, unexpected format).

## test_bounty_index.py: 39 → 72 tests (+33)
Upgraded TestEstimateDifficulty with exact tier assertions at all boundaries (micro <10, standard 10-49, major 50-199, critical 200+) and label-override tests. Extended TestTagSkills (docker, security, ci/cd, translation, sorted, no-dupe). Extended TestFormatMarkdown (header, skills, truncation). New TestAggregate (keys, count, sort, ISO timestamp). Extended TestFetchBountiesIntegration (enrichment, 404, network error, multi-repo).

## Evidence


Refs Scottcjn/rustchain-bounties#526

**BCOS-L1**

**Wallet:** RTC-agent-fino31415-d969