### PR TITLE
Fix RustChain branding in docs tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ RustChain is a blockchain that rewards real hardware -- especially vintage machi
 
 | Repository | Description | Stars | Bounties |
 |------------|-------------|-------|----------|
-| [Rustchain](https://github.com/Scottcjn/Rustchain) | Core blockchain node -- Proof-of-Antiquity consensus, RIP-200/201, hardware attestation | 78 | Yes |
+| [RustChain](https://github.com/Scottcjn/Rustchain) | Core blockchain node -- Proof-of-Antiquity consensus, RIP-200/201, hardware attestation | 78 | Yes |
 | [rustchain-bounties](https://github.com/Scottcjn/rustchain-bounties) | Bounty board -- all open tasks, red-team challenges, community rewards | 31 | 154+ |
 | [bottube](https://github.com/Scottcjn/bottube) | AI video platform -- 99 agents, 670+ videos, Python SDK (`pip install bottube`) | 64 | Yes |
 | [beacon-skill](https://github.com/Scottcjn/beacon-skill) | Agent-to-agent coordination -- ping, mayday, contracts with RTC value attached | 45 | Yes |

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -387,7 +387,7 @@ Dev.to, or SaaSCity. Check the individual issue for exact requirements.
 
 | Repository | Description |
 |------------|-------------|
-| [Rustchain](https://github.com/Scottcjn/Rustchain) | Core blockchain node with RIP-200/201 consensus |
+| [RustChain](https://github.com/Scottcjn/Rustchain) | Core blockchain node with RIP-200/201 consensus |
 | [rustchain-bounties](https://github.com/Scottcjn/rustchain-bounties) | Bounty board with 154+ open tasks |
 | [bottube](https://github.com/Scottcjn/bottube) | AI video platform with Python SDK (`pip install bottube`) |
 | [beacon-skill](https://github.com/Scottcjn/beacon-skill) | Agent-to-agent coordination protocol |

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -145,7 +145,7 @@ and has its own bounty issues:
 | Repository | Language | Description |
 |------------|----------|-------------|
 | [rustchain-bounties](https://github.com/Scottcjn/rustchain-bounties) | -- | Bounty board with 154+ open tasks (file claims here) |
-| [Rustchain](https://github.com/Scottcjn/Rustchain) | Python | Core blockchain node -- RIP-200/201 consensus, attestation |
+| [RustChain](https://github.com/Scottcjn/Rustchain) | Python | Core blockchain node -- RIP-200/201 consensus, attestation |
 | [bottube](https://github.com/Scottcjn/bottube) | Python | AI video platform, Python SDK (`pip install bottube`) |
 | [beacon-skill](https://github.com/Scottcjn/beacon-skill) | Python | Agent-to-agent coordination protocol |
 | [ram-coffers](https://github.com/Scottcjn/ram-coffers) | C | NUMA-distributed weight banking for LLM inference |


### PR DESCRIPTION
## Summary
- update user-facing docs table labels from "Rustchain" to "RustChain"
- keep the existing Scottcjn/Rustchain repository URLs unchanged
- apply the same casing in README, Getting Started, and FAQ ecosystem tables

## Validation
- git diff --check HEAD~1..HEAD
- duplicate check: no open bounty-concierge PR matched this RustChain capitalization fix