### PR TITLE
Fix contributing guide commands

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,18 +30,18 @@ cd bounty-concierge
 # Install dependencies
 pip install -r requirements.txt
 
-# Run the tool
-python bounty_concierge.py --help
+# Run the tool from the source checkout
+python3 -m concierge --help
 ```
 
 ## 🧪 Testing
 
 ```bash
 # Run tests
-pytest tests/
+python3 -m pytest tests/
 
 # Run with coverage
-pytest --cov=bounty_concierge tests/
+python3 -m pytest --cov=concierge tests/
 ```
 
 ## 📝 Code Style


### PR DESCRIPTION
## Summary
- replace the stale `python bounty_concierge.py --help` command with the working source checkout entrypoint
- update test commands to use `python3 -m pytest` and the actual `concierge` coverage module

## Validation
- `python3 -m concierge --help`
- `python3 -m pytest tests/ -q` -> 175 passed
- `git diff --check -- CONTRIBUTING.md`

Bounty reference: Scottcjn/rustchain-bounties#2178