### PR TITLE
docs: avoid stale ecosystem counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,25 +48,28 @@ RustChain is a blockchain that rewards real hardware -- especially vintage machi
 | rustchain-bounties | [#512](https://github.com/Scottcjn/rustchain-bounties/issues/512) | Share RustChain on Social Media | 2 | Micro | Community |
 | rustchain-bounties | [#511](https://github.com/Scottcjn/rustchain-bounties/issues/511) | Star 5+ Repos Challenge | 2 | Micro | Community |
 
-**154+ bounties currently open.** See the [full list](https://github.com/Scottcjn/rustchain-bounties/issues?q=is%3Aopen+label%3Abounty).
+Open bounty totals change frequently. See the [live full list](https://github.com/Scottcjn/rustchain-bounties/issues?q=is%3Aopen+label%3Abounty) for the current count.
 
 ---
 
 ## Ecosystem Map
 
+> Counts in this table intentionally link to live GitHub views instead of
+> hard-coding volatile star or bounty totals.
+
 | Repository | Description | Stars | Bounties |
 |------------|-------------|-------|----------|
-| [RustChain](https://github.com/Scottcjn/Rustchain) | Core blockchain node -- Proof-of-Antiquity consensus, RIP-200/201, hardware attestation | 78 | Yes |
-| [rustchain-bounties](https://github.com/Scottcjn/rustchain-bounties) | Bounty board -- all open tasks, red-team challenges, community rewards | 31 | 154+ |
-| [bottube](https://github.com/Scottcjn/bottube) | AI video platform -- 99 agents, 670+ videos, Python SDK (`pip install bottube`) | 64 | Yes |
-| [beacon-skill](https://github.com/Scottcjn/beacon-skill) | Agent-to-agent coordination -- ping, mayday, contracts with RTC value attached | 45 | Yes |
-| [ram-coffers](https://github.com/Scottcjn/ram-coffers) | NUMA-distributed weight banking for LLM inference (predates DeepSeek Engram by 27 days) | 27 | Yes |
-| [claude-code-power8](https://github.com/Scottcjn/claude-code-power8) | First POWER8/ppc64le port of Claude Code CLI | 16 | Yes |
-| [llama-cpp-power8](https://github.com/Scottcjn/llama-cpp-power8) | AltiVec/VSX optimized llama.cpp for IBM POWER8 | 13 | Yes |
-| [nvidia-power8-patches](https://github.com/Scottcjn/nvidia-power8-patches) | Modern NVIDIA drivers for IBM POWER8 via OCuLink | 17 | Yes |
-| [rustchain-monitor](https://github.com/Scottcjn/rustchain-monitor) | Real-time monitoring tool for PoA blockchain nodes | 14 | Yes |
-| [claude-code-ppc](https://github.com/Scottcjn/claude-code-ppc) | Claude Code on Mac OS X Leopard (2007) -- PowerPC G5, native TLS 1.2 | 14 | Yes |
-| [grazer-skill](https://github.com/Scottcjn/grazer-skill) | Claude Code skill for grazing content across BoTTube, Moltbook, and ClawCities | 31 | Yes |
+| [RustChain](https://github.com/Scottcjn/Rustchain) | Core blockchain node -- Proof-of-Antiquity consensus, RIP-200/201, hardware attestation | [Live](https://github.com/Scottcjn/Rustchain/stargazers) | [Issues](https://github.com/Scottcjn/Rustchain/issues?q=is%3Aopen) |
+| [rustchain-bounties](https://github.com/Scottcjn/rustchain-bounties) | Bounty board -- all open tasks, red-team challenges, community rewards | [Live](https://github.com/Scottcjn/rustchain-bounties/stargazers) | [Live bounties](https://github.com/Scottcjn/rustchain-bounties/issues?q=is%3Aopen+label%3Abounty) |
+| [bottube](https://github.com/Scottcjn/bottube) | AI video platform -- 99 agents, 670+ videos, Python SDK (`pip install bottube`) | [Live](https://github.com/Scottcjn/bottube/stargazers) | [Issues](https://github.com/Scottcjn/bottube/issues?q=is%3Aopen) |
+| [beacon-skill](https://github.com/Scottcjn/beacon-skill) | Agent-to-agent coordination -- ping, mayday, contracts with RTC value attached | [Live](https://github.com/Scottcjn/beacon-skill/stargazers) | [Issues](https://github.com/Scottcjn/beacon-skill/issues?q=is%3Aopen) |
+| [ram-coffers](https://github.com/Scottcjn/ram-coffers) | NUMA-distributed weight banking for LLM inference (predates DeepSeek Engram by 27 days) | [Live](https://github.com/Scottcjn/ram-coffers/stargazers) | [Issues](https://github.com/Scottcjn/ram-coffers/issues?q=is%3Aopen) |
+| [claude-code-power8](https://github.com/Scottcjn/claude-code-power8) | First POWER8/ppc64le port of Claude Code CLI | [Live](https://github.com/Scottcjn/claude-code-power8/stargazers) | [Issues](https://github.com/Scottcjn/claude-code-power8/issues?q=is%3Aopen) |
+| [llama-cpp-power8](https://github.com/Scottcjn/llama-cpp-power8) | AltiVec/VSX optimized llama.cpp for IBM POWER8 | [Live](https://github.com/Scottcjn/llama-cpp-power8/stargazers) | [Issues](https://github.com/Scottcjn/llama-cpp-power8/issues?q=is%3Aopen) |
+| [nvidia-power8-patches](https://github.com/Scottcjn/nvidia-power8-patches) | Modern NVIDIA drivers for IBM POWER8 via OCuLink | [Live](https://github.com/Scottcjn/nvidia-power8-patches/stargazers) | [Issues](https://github.com/Scottcjn/nvidia-power8-patches/issues?q=is%3Aopen) |
+| [rustchain-monitor](https://github.com/Scottcjn/rustchain-monitor) | Real-time monitoring tool for PoA blockchain nodes | [Live](https://github.com/Scottcjn/rustchain-monitor/stargazers) | [Issues](https://github.com/Scottcjn/rustchain-monitor/issues?q=is%3Aopen) |
+| [claude-code-ppc](https://github.com/Scottcjn/claude-code-ppc) | Claude Code on Mac OS X Leopard (2007) -- PowerPC G5, native TLS 1.2 | [Live](https://github.com/Scottcjn/claude-code-ppc/stargazers) | [Issues](https://github.com/Scottcjn/claude-code-ppc/issues?q=is%3Aopen) |
+| [grazer-skill](https://github.com/Scottcjn/grazer-skill) | Claude Code skill for grazing content across BoTTube, Moltbook, and ClawCities | [Live](https://github.com/Scottcjn/grazer-skill/stargazers) | [Issues](https://github.com/Scottcjn/grazer-skill/issues?q=is%3Aopen) |
 | [bounty-concierge](https://github.com/Scottcjn/bounty-concierge) | **This repo** -- onboarding, CLI tool, docs index | -- | -- |
 
 ---


### PR DESCRIPTION
## Summary
- replace the stale hard-coded open-bounty total in the README with a live-list link
- replace volatile ecosystem map star/bounty numbers with live GitHub links
- add a short note explaining why the table avoids hard-coded counts

## Verification
- `git diff --check`
- searched README for the stale counts called out in #39

Refs #39