### PR TITLE
docs: stabilize ecosystem map counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,26 +48,26 @@ RustChain is a blockchain that rewards real hardware -- especially vintage machi
 | rustchain-bounties | [#512](https://github.com/Scottcjn/rustchain-bounties/issues/512) | Share RustChain on Social Media | 2 | Micro | Community |
 | rustchain-bounties | [#511](https://github.com/Scottcjn/rustchain-bounties/issues/511) | Star 5+ Repos Challenge | 2 | Micro | Community |
 
-**154+ bounties currently open.** See the [full list](https://github.com/Scottcjn/rustchain-bounties/issues?q=is%3Aopen+label%3Abounty).
+For the current open-bounty count, use the live badge above or see the [full list](https://github.com/Scottcjn/rustchain-bounties/issues?q=is%3Aopen+label%3Abounty).
 
 ---
 
 ## Ecosystem Map
 
-| Repository | Description | Stars | Bounties |
-|------------|-------------|-------|----------|
-| [RustChain](https://github.com/Scottcjn/Rustchain) | Core blockchain node -- Proof-of-Antiquity consensus, RIP-200/201, hardware attestation | 78 | Yes |
-| [rustchain-bounties](https://github.com/Scottcjn/rustchain-bounties) | Bounty board -- all open tasks, red-team challenges, community rewards | 31 | 154+ |
-| [bottube](https://github.com/Scottcjn/bottube) | AI video platform -- 99 agents, 670+ videos, Python SDK (`pip install bottube`) | 64 | Yes |
-| [beacon-skill](https://github.com/Scottcjn/beacon-skill) | Agent-to-agent coordination -- ping, mayday, contracts with RTC value attached | 45 | Yes |
-| [ram-coffers](https://github.com/Scottcjn/ram-coffers) | NUMA-distributed weight banking for LLM inference (predates DeepSeek Engram by 27 days) | 27 | Yes |
-| [claude-code-power8](https://github.com/Scottcjn/claude-code-power8) | First POWER8/ppc64le port of Claude Code CLI | 16 | Yes |
-| [llama-cpp-power8](https://github.com/Scottcjn/llama-cpp-power8) | AltiVec/VSX optimized llama.cpp for IBM POWER8 | 13 | Yes |
-| [nvidia-power8-patches](https://github.com/Scottcjn/nvidia-power8-patches) | Modern NVIDIA drivers for IBM POWER8 via OCuLink | 17 | Yes |
-| [rustchain-monitor](https://github.com/Scottcjn/rustchain-monitor) | Real-time monitoring tool for PoA blockchain nodes | 14 | Yes |
-| [claude-code-ppc](https://github.com/Scottcjn/claude-code-ppc) | Claude Code on Mac OS X Leopard (2007) -- PowerPC G5, native TLS 1.2 | 14 | Yes |
-| [grazer-skill](https://github.com/Scottcjn/grazer-skill) | Claude Code skill for grazing content across BoTTube, Moltbook, and ClawCities | 31 | Yes |
-| [bounty-concierge](https://github.com/Scottcjn/bounty-concierge) | **This repo** -- onboarding, CLI tool, docs index | -- | -- |
+| Repository | Description | Status |
+|------------|-------------|--------|
+| [RustChain](https://github.com/Scottcjn/Rustchain) | Core blockchain node -- Proof-of-Antiquity consensus, RIP-200/201, hardware attestation | Active ecosystem repo |
+| [rustchain-bounties](https://github.com/Scottcjn/rustchain-bounties) | Bounty board -- all open tasks, red-team challenges, community rewards | Live bounty board |
+| [bottube](https://github.com/Scottcjn/bottube) | AI video platform -- agents, videos, Python SDK (`pip install bottube`) | Active ecosystem repo |
+| [beacon-skill](https://github.com/Scottcjn/beacon-skill) | Agent-to-agent coordination -- ping, mayday, contracts with RTC value attached | Active ecosystem repo |
+| [ram-coffers](https://github.com/Scottcjn/ram-coffers) | NUMA-distributed weight banking for LLM inference (predates DeepSeek Engram by 27 days) | Active ecosystem repo |
+| [claude-code-power8](https://github.com/Scottcjn/claude-code-power8) | First POWER8/ppc64le port of Claude Code CLI | Active ecosystem repo |
+| [llama-cpp-power8](https://github.com/Scottcjn/llama-cpp-power8) | AltiVec/VSX optimized llama.cpp for IBM POWER8 | Active ecosystem repo |
+| [nvidia-power8-patches](https://github.com/Scottcjn/nvidia-power8-patches) | Modern NVIDIA drivers for IBM POWER8 via OCuLink | Active ecosystem repo |
+| [rustchain-monitor](https://github.com/Scottcjn/rustchain-monitor) | Real-time monitoring tool for PoA blockchain nodes | Active ecosystem repo |
+| [claude-code-ppc](https://github.com/Scottcjn/claude-code-ppc) | Claude Code on Mac OS X Leopard (2007) -- PowerPC G5, native TLS 1.2 | Active ecosystem repo |
+| [grazer-skill](https://github.com/Scottcjn/grazer-skill) | Claude Code skill for grazing content across BoTTube, Moltbook, and ClawCities | Active ecosystem repo |
+| [bounty-concierge](https://github.com/Scottcjn/bounty-concierge) | **This repo** -- onboarding, CLI tool, docs index | Start here |
 
 ---
 

--- a/tests/test_readme_ecosystem_map.py
+++ b/tests/test_readme_ecosystem_map.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+
+
+def test_ecosystem_map_avoids_stale_static_counts():
+    readme = Path("README.md").read_text(encoding="utf-8")
+    ecosystem = readme.split("## Ecosystem Map", 1)[1].split("## Key Concepts", 1)[0]
+
+    assert "| Stars |" not in ecosystem
+    assert "154+" not in ecosystem
+    assert "78 |" not in ecosystem
+    assert "64 |" not in ecosystem
+    assert "45 |" not in ecosystem


### PR DESCRIPTION
## Summary
- Replace stale static open-bounty and star counts with live-link/status wording.
- Keep the ecosystem map useful for onboarding without hardcoding volatile GitHub metrics.
- Add a focused README regression test to prevent the old stale counts from returning.

Fixes #39.

## Testing
- `python -c "import runpy; ns=runpy.run_path('tests/test_readme_ecosystem_map.py'); ns['test_ecosystem_map_avoids_stale_static_counts'](); print('README_ECOSYSTEM_MAP_CHECK=passed')"`
- `python -c "from pathlib import Path; text=Path('README.md').read_text(encoding='utf-8'); assert '154+ bounties currently open' not in text; print('README_STALE_COUNT_CHECK=passed')"`
- `git diff --check`
- Attempted: `python -m pytest tests/test_readme_ecosystem_map.py -q` (pytest is not installed in this local Python environment)

## Bounty Claim
- Issue number: Scottcjn/bounty-concierge#39 / Scottcjn/rustchain-bounties#100
- Wallet ID: RTCc1a1c639df2f704fb9068e9e4f820cf9184f3675

I did not submit any private key, token, seed, mnemonic, or wallet secret.