### PR TITLE
fix(pow): miner detection regexes never match (double-escaped raw strings)

### DIFF
--- a/concierge/pow_miners.py
+++ b/concierge/pow_miners.py
@@ -139,9 +139,9 @@ def detect_pow_processes() -> Dict:
     else:
         lines = stdout.splitlines()
 
-    bz_re = re.compile(r"\\bbzminer\\b.*(?:-a\\s+warthog|-a=warthog)", re.IGNORECASE)
-    janus_re = re.compile(r"\\bjanusminer(?:-ubuntu\\S*)?\\b", re.IGNORECASE)
-    node_re = re.compile(r"\\bwart-node(?:-linux)?\\b", re.IGNORECASE)
+    bz_re = re.compile(r"\bbzminer\b.*(?:-a\s+warthog|-a=warthog)", re.IGNORECASE)
+    janus_re = re.compile(r"\bjanusminer(?:-ubuntu\S*)?\b", re.IGNORECASE)
+    node_re = re.compile(r"\bwart-node(?:-linux)?\b", re.IGNORECASE)
 
     for line in lines:
         cmd = line.strip()

--- a/tests/test_pow_miners.py
+++ b/tests/test_pow_miners.py
@@ -103,6 +103,59 @@ class TestMinerCommands:
         assert command == ["janus", "-a", "RTCwallet", "-h", "10.0.0.5", "-p", "4444"]
 
 
+class TestDetectPowProcesses:
+    """A running warthog miner must actually be detected from `ps` output.
+
+    Regression guard for the double-escaped regexes: with ``r"\\bbzminer\\b"``
+    the pattern required a literal backslash before the process name, so a real
+    ``ps -eo args`` line never matched and every miner went undetected.
+    """
+
+    def _fake_run(self, ps_output):
+        def _runner(command, timeout=5):
+            if command[:1] == ["ps"]:
+                return 0, ps_output, ""
+            # systemctl / screen: report nothing running
+            return 1, "", "unavailable"
+        return _runner
+
+    @patch("concierge.pow_miners._run_command")
+    def test_detects_bzminer_from_ps(self, mock_run):
+        mock_run.side_effect = self._fake_run(
+            "bzminer -a warthog -w RTCwallet -p stratum+tcp://pool.woolypooly.com:3140\n"
+        )
+
+        result = pow_miners.detect_pow_processes()
+
+        assert result["detected"] is True
+        assert result["external_miner_detected"] is True
+        assert any(p["type"] == "bzminer" for p in result["processes"])
+
+    @patch("concierge.pow_miners._run_command")
+    def test_detects_janusminer_and_wart_node_from_ps(self, mock_run):
+        mock_run.side_effect = self._fake_run(
+            "/usr/local/bin/janusminer-ubuntu22 -a RTCwallet -h 127.0.0.1 -p 3000\n"
+            "wart-node-linux --rpc\n"
+        )
+
+        result = pow_miners.detect_pow_processes()
+
+        types = {p["type"] for p in result["processes"]}
+        assert {"janusminer", "wart-node"} <= types
+        assert result["detected"] is True
+
+    @patch("concierge.pow_miners._run_command")
+    def test_unrelated_processes_are_not_detected(self, mock_run):
+        mock_run.side_effect = self._fake_run(
+            "python3 concierge/cli.py status\nbash -lc echo warthog\n"
+        )
+
+        result = pow_miners.detect_pow_processes()
+
+        assert result["processes"] == []
+        assert result["detected"] is False
+
+
 class TestNodeRpc:
     def _response(self, ok=True, status_code=200, payload=None):
         resp = MagicMock()


### PR DESCRIPTION
## Bug: PoW miner detection never matches (double-escaped regexes)

`detect_pow_processes()` in `concierge/pow_miners.py` builds three regexes as raw strings **with doubled backslashes**:

```python
bz_re    = re.compile(r"\\bbzminer\\b.*(?:-a\\s+warthog|-a=warthog)", re.IGNORECASE)
janus_re = re.compile(r"\\bjanusminer(?:-ubuntu\\S*)?\\b", re.IGNORECASE)
node_re  = re.compile(r"\\bwart-node(?:-linux)?\\b", re.IGNORECASE)
```

In a raw string `r"\\b"` is **two backslashes + b**, so the compiled pattern requires a *literal backslash* before the miner name, and `\\s` matches a literal backslash instead of whitespace. A real `ps -eo args` line (e.g. `bzminer -a warthog -w RTCwallet -p ...`) contains no backslash there, so **none of the three patterns ever match**.

### Impact
Every warthog/Janushash miner is missed: `processes` stays empty, `detected`/`external_miner_detected` stay `False`, and `calculate_bonus_multiplier()` silently drops the `external_miner_detected` (1.15x) and managed-subprocess reward factors. A hunter who *is* dual-mining gets **understated rewards** because the detector reports nothing running.

### Reproduction
```python
import re
bz = re.compile(r"\\bbzminer\\b.*(?:-a\\s+warthog|-a=warthog)", re.IGNORECASE)
print(bool(bz.search("bzminer -a warthog -w RTCwallet -p stratum+tcp://pool:3140")))  # -> False (bug)
```

### Fix
Use single-backslash word boundaries — the raw string already handles the escape:

```python
bz_re    = re.compile(r"\bbzminer\b.*(?:-a\s+warthog|-a=warthog)", re.IGNORECASE)
janus_re = re.compile(r"\bjanusminer(?:-ubuntu\S*)?\b", re.IGNORECASE)
node_re  = re.compile(r"\bwart-node(?:-linux)?\b", re.IGNORECASE)
```

With the fix the same line matches `True`, and unrelated processes still don't.

### Tests
Added `TestDetectPowProcesses` (mocks `_run_command`): a real bzminer line is detected, janusminer + wart-node are detected, and unrelated processes (including one merely containing the word "warthog") are not. Full suite: **224 passed**. Reverting the one-line fix fails the new tests (mutation-guarded).

---
RTC payout wallet: `RTCd1554f0f35576faf01d386a6be1c947f560dd0b7`
