### PR TITLE
Fix install path: working build backend, GitHub install docs, drop clawrtc script collision

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,11 @@ RustChain is a blockchain that rewards real hardware -- especially vintage machi
 | Step | Action | Details |
 |------|--------|---------|
 | 1 | **Pick your skill level** | See [docs/SKILL_MATRIX.md](docs/SKILL_MATRIX.md) -- bounties exist for every level from "star a repo" to "break the consensus engine" |
-| 2 | **Browse bounties** | Run `concierge browse` or scroll to the [Open Bounties](#open-bounties) table below |
-| 3 | **Register a wallet** | Run `concierge wallet register YOUR_NAME` or open a [wallet registration issue](https://github.com/Scottcjn/rustchain-bounties/issues/new?template=wallet_registration.md) |
-| 4 | **Claim a bounty** | Comment on the GitHub issue with your wallet name and a brief approach description |
-| 5 | **Get paid** | RTC is transferred to your wallet within 24 hours after your PR is merged |
+| 2 | **Install the CLI** | Run `pip install git+https://github.com/Scottcjn/bounty-concierge.git` (see [Installation](#installation)) |
+| 3 | **Browse bounties** | Run `concierge browse` or scroll to the [Open Bounties](#open-bounties) table below |
+| 4 | **Register a wallet** | Run `concierge wallet register YOUR_NAME` or open a [wallet registration issue](https://github.com/Scottcjn/rustchain-bounties/issues/new?template=wallet_registration.md) |
+| 5 | **Claim a bounty** | Comment on the GitHub issue with your wallet name and a brief approach description |
+| 6 | **Get paid** | RTC is transferred to your wallet within 24 hours after your PR is merged |
 
 ---
 
@@ -110,9 +111,13 @@ For a deep dive, see [docs/TECH_STACK.md](docs/TECH_STACK.md).
 
 ### Installation
 
+Install straight from GitHub:
+
 ```bash
-pip install bounty-concierge
+pip install git+https://github.com/Scottcjn/bounty-concierge.git
 ```
+
+> PyPI publication is pending, so `pip install bounty-concierge` does not work yet. The GitHub install above is the supported path for now.
 
 ### Usage
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["setuptools>=82.0.1"]
-build-backend = "setuptools.backends._legacy:_Backend"
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
 
 [project]
 name = "bounty-concierge"
@@ -13,4 +13,6 @@ dependencies = ["requests>=2.32.5"]
 
 [project.scripts]
 concierge = "concierge.cli:main"
-clawrtc = "concierge.cli:main"
+
+[tool.setuptools.packages.find]
+include = ["concierge*"]


### PR DESCRIPTION
The Quick Start told people to run `pip install bounty-concierge`, which 404s because the package was never published to PyPI. Worse, even `pip install git+.../bounty-concierge.git` failed, because pyproject.toml declared a build backend that does not exist:

```
pip._vendor.pyproject_hooks._impl.BackendUnavailable: Cannot import 'setuptools.backends._legacy'
```

Changes:
- pyproject.toml: use the standard `setuptools.build_meta` backend, scope package discovery to `concierge*` so pip only picks up the actual package
- pyproject.toml: remove the `clawrtc` console script alias, which shadowed the real Rust `clawrtc` binary on PATH
- README: install via `pip install git+https://github.com/Scottcjn/bounty-concierge.git`, with an honest note that PyPI publication is pending, and an explicit install step in the Quick Start table

Verified in a clean venv against this branch:

```
$ pip install "git+https://github.com/Scottcjn/bounty-concierge.git@fix-install-instructions"
Successfully installed bounty-concierge-0.1.0 ...
$ concierge version
bounty-concierge 0.1.0
$ concierge browse --limit 3
(returns the live bounty table)
```

No `clawrtc` script is installed anymore, only `concierge`.

Known gap not fixed here: `concierge faq` doc lookup uses a repo-relative `docs/` dir that is not shipped in the wheel, so FAQ answers from local docs are unavailable in an installed copy. Everything else in the CLI works installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)