### PR TITLE
Update reference rate to $0.15 and wRTC chain to Solana

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 ## What is RustChain?
 
-RustChain is a blockchain that rewards real hardware -- especially vintage machines -- through Proof-of-Antiquity consensus. A PowerPC G4 from 2001 earns 2.5x more than a modern server, because preservation matters. The native utility token is **RTC**, valued at **$0.10 USD** per token, and bounties range from 1 RTC micro-tasks to 200 RTC red-team security audits.
+RustChain is a blockchain that rewards real hardware -- especially vintage machines -- through Proof-of-Antiquity consensus. A PowerPC G4 from 2001 earns 2.5x more than a modern server, because preservation matters. The native utility token is **RTC**, with an internal reference rate of **$0.15 USD** per token, and bounties range from 1 RTC micro-tasks to 200 RTC red-team security audits.
 
 ---
 
@@ -98,8 +98,8 @@ For a deep dive, see [docs/TECH_STACK.md](docs/TECH_STACK.md).
 |---------|---------|
 | **RIP-200** | 1 CPU = 1 Vote. Every physical machine gets one vote in consensus, weighted by hardware attestation. No GPU farms, no cloud VMs. |
 | **Proof-of-Antiquity** | Vintage hardware earns higher rewards. G4 = 2.5x, G5 = 2.0x, G3 = 1.8x, Apple Silicon = 1.2x, modern x86 = 1.0x. Multipliers decay over ~17 years. |
-| **RTC Token** | Native utility token of the RustChain network. Reference rate: **1 RTC = $0.10 USD**. Used for bounties, agent economy, and miner rewards. |
-| **wRTC** | Wrapped RTC on Base L2 for DeFi access. Bridges RTC from the attestation chain to Ethereum L2 liquidity. |
+| **RTC Token** | Native utility token of the RustChain network. Reference rate: **1 RTC = $0.15 USD** (live rate at [rustchain.org/api/tokenomics](https://rustchain.org/api/tokenomics)). Used for bounties, agent economy, and miner rewards. |
+| **wRTC** | Wrapped RTC on Solana (SPL token) for DeFi access. Official bridge: [bottube.ai/bridge/wrtc](https://bottube.ai/bridge/wrtc). Liquidity is early-stage and thin; treat it as experimental. |
 | **RIP-201** | Fleet immune system. Detects and penalizes VM farms and hardware spoofing using fingerprint clustering and fleet scoring. |
 | **Beacon Protocol** | Agent-to-agent coordination layer. Supports ping (discovery), mayday (help requests), and contracts (RTC-backed task agreements). |
 | **Hebbian / PSE** | POWER8 vec_perm non-bijunctive collapse. Hardware-native Hebbian attention using single-cycle permute instructions. Research frontier, not required for bounties. |

--- a/concierge/announcer.py
+++ b/concierge/announcer.py
@@ -63,7 +63,7 @@ def format_announcement(bounties: List[dict]) -> Dict[str, str]:
             f"| [link]({b.get('url', '')}) |"
         )
     long_lines.append(
-        "\n1 RTC = $0.10 USD.  "
+        "\n1 RTC = $0.15 USD.  "
         "See https://github.com/Scottcjn/bounty-concierge for details."
     )
     long = "\n".join(long_lines)

--- a/concierge/faq_engine.py
+++ b/concierge/faq_engine.py
@@ -22,7 +22,8 @@ FAQ_ENTRIES = {
     "what is rtc": (
         "RTC (RustChain Token) is the native token of the RustChain network. "
         "It rewards miners for hardware attestation under the RIP-200 consensus "
-        "protocol.  Internal reference rate: 1 RTC = $0.10 USD."
+        "protocol.  Internal reference rate: 1 RTC = $0.15 USD (live rate "
+        "at https://rustchain.org/api/tokenomics)."
     ),
     "how do i set up a wallet": (
         "Install the RustChain wallet package (Standard, Founder, or Secure "
@@ -37,9 +38,11 @@ FAQ_ENTRIES = {
         "wallet balance within one epoch (~10 minutes)."
     ),
     "what is wrtc": (
-        "wRTC (Wrapped RTC) is a planned representation of RTC on the Ergo "
-        "blockchain, enabling DEX trading.  The RTC/ERG DEX bounty (Issue #32) "
-        "offers 150 RTC for building this bridge."
+        "wRTC (Wrapped RTC) is the Solana representation of RTC (SPL token, "
+        "6 decimals), live and swappable with early-stage, thin liquidity.  "
+        "Official bridge: https://bottube.ai/bridge/wrtc.  Always verify the "
+        "token mint 12TAdKXxcGf6oCv4rqDz2NkgxjyHq6HQKoxKZYGf5i4X before "
+        "trading."
     ),
     "what is proof of antiquity": (
         "Proof of Antiquity (PoA) is RustChain's unique consensus mechanism "
@@ -120,9 +123,10 @@ FAQ_ENTRIES = {
         "personalities."
     ),
     "rtc value": (
-        "Internal reference rate: 1 RTC = $0.10 USD.  This is a planning "
-        "rate for bounty pricing, not a market price.  RTC is not yet traded "
-        "on any exchange."
+        "Internal reference rate: 1 RTC = $0.15 USD (live rate at "
+        "https://rustchain.org/api/tokenomics).  This is a planning rate for "
+        "bounty pricing, not a market price.  wRTC trades on Solana with "
+        "early-stage, thin liquidity."
     ),
     "how do i claim a bounty": (
         "Comment on the GitHub issue saying you want to work on it, and "

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -21,16 +21,18 @@ December 2, 2025. Primary node: `https://50.28.86.131`.
 RTC (RustChain Token) is the native utility token of the RustChain
 blockchain. It is earned through hardware mining (Proof-of-Antiquity),
 bounty rewards, and agent economy participation. The internal reference
-rate is **1 RTC = $0.10 USD**. RTC uses 6 decimal places internally
+rate is **1 RTC = $0.15 USD** (live rate at
+https://rustchain.org/api/tokenomics). RTC uses 6 decimal places internally
 (1 RTC = 1,000,000 units).
 
 ### 3. What is wRTC?
 
-wRTC (wrapped RTC) is an ERC-20 token on **Base L2** (Ethereum layer-2)
-that represents RTC on a public chain. It uses a custodial mint/burn
-bridge with 6 decimal places. The bridge enables DeFi trading, liquidity
-pools, and interoperability with other ERC-20 tokens. The wRTC bridge is
-under active development and not yet live.
+wRTC (wrapped RTC) is an SPL token on **Solana** that represents RTC on
+a public chain. It uses a custodial mint/burn bridge with 6 decimal
+places (official bridge: https://bottube.ai/bridge/wrtc, token mint
+`12TAdKXxcGf6oCv4rqDz2NkgxjyHq6HQKoxKZYGf5i4X`). wRTC is live and
+swappable, but liquidity is early-stage and thin; treat it as
+experimental.
 
 ### 4. How do I get a wallet?
 
@@ -66,16 +68,18 @@ You can also browse balances in the block explorer at
 
 ### 6. How much is 1 RTC worth?
 
-The internal reference rate is **$0.10 USD per RTC**. This rate is used
-for pricing bounties and valuing contributions. Market price may differ
-once wRTC is live on Base L2. At the current rate:
+The internal reference rate is **$0.15 USD per RTC** (live rate at
+https://rustchain.org/api/tokenomics). This rate is used for pricing
+bounties and valuing contributions. wRTC trades on Solana with
+early-stage, thin liquidity, so market price may differ. At the current
+rate:
 
 | Bounty | RTC | USD |
 |--------|-----|-----|
-| Micro (small) | 5 RTC | $0.50 |
-| Standard (medium) | 30 RTC | $3.00 |
-| Major (large) | 150 RTC | $15.00 |
-| Critical (expert) | 300 RTC | $30.00 |
+| Micro (small) | 5 RTC | $0.75 |
+| Standard (medium) | 30 RTC | $4.50 |
+| Major (large) | 150 RTC | $22.50 |
+| Critical (expert) | 300 RTC | $45.00 |
 
 ---
 
@@ -87,10 +91,10 @@ Bounties are sized by complexity and value:
 
 | Tier | RTC Range | USD Equivalent | Typical Scope |
 |------|-----------|----------------|---------------|
-| Micro | 1 - 10 RTC | $0.10 - $1.00 | Docs, typo fixes, repo stars, social shares |
-| Standard | 10 - 50 RTC | $1.00 - $5.00 | Feature additions, integrations, test suites |
-| Major | 50 - 200 RTC | $5.00 - $20.00 | Architecture work, protocol implementations |
-| Critical | 200 - 500 RTC | $20.00 - $50.00 | Security audits, core consensus changes, red-team |
+| Micro | 1 - 10 RTC | $0.15 - $1.50 | Docs, typo fixes, repo stars, social shares |
+| Standard | 10 - 50 RTC | $1.50 - $7.50 | Feature additions, integrations, test suites |
+| Major | 50 - 200 RTC | $7.50 - $30.00 | Architecture work, protocol implementations |
+| Critical | 200 - 500 RTC | $30.00 - $75.00 | Security audits, core consensus changes, red-team |
 
 ### 8. How do I claim a bounty?
 
@@ -185,10 +189,12 @@ You can also view transactions in the block explorer at
 
 ### 17. Can I trade or cash out RTC?
 
-Direct on-chain trading is not yet live. The wRTC bridge to Base L2 is
-under development. Currently, RTC can be transferred between wallets
-using the signed transfer endpoint or through OTC (over-the-counter)
-arrangements. The reference rate for OTC is 1 RTC = $0.10 USD.
+Yes, with caveats. wRTC trades on Solana (bridge at
+https://bottube.ai/bridge/wrtc), but liquidity is early-stage and thin.
+RTC can also be transferred between wallets using the signed transfer
+endpoint or through OTC (over-the-counter) arrangements. The internal
+reference rate is 1 RTC = $0.15 USD, which is a planning rate, not a
+market price.
 
 ---
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -31,10 +31,10 @@ indicate the tier:
 
 | Label | RTC Range | USD Value | Difficulty |
 |-------|-----------|-----------|------------|
-| `micro` | 1 - 10 | $0.10 - $1.00 | Easy -- docs, typos, repo stars, social shares |
-| `standard` | 10 - 50 | $1.00 - $5.00 | Medium -- features, integrations, tests |
-| `major` | 50 - 200 | $5.00 - $20.00 | Hard -- architecture, protocol work |
-| `critical` | 200 - 500 | $20.00 - $50.00 | Expert -- security audits, consensus |
+| `micro` | 1 - 10 | $0.15 - $1.50 | Easy -- docs, typos, repo stars, social shares |
+| `standard` | 10 - 50 | $1.50 - $7.50 | Medium -- features, integrations, tests |
+| `major` | 50 - 200 | $7.50 - $30.00 | Hard -- architecture, protocol work |
+| `critical` | 200 - 500 | $30.00 - $75.00 | Expert -- security audits, consensus |
 
 **If this is your first bounty**, start with a `micro` issue. Get one
 merged, see RTC hit your wallet, then scale up.

--- a/docs/PAYOUT_GUIDE.md
+++ b/docs/PAYOUT_GUIDE.md
@@ -7,7 +7,8 @@ Step-by-step instructions for earning and receiving RTC bounty payouts.
 ## Overview
 
 RustChain bounties are paid in RTC (RustChain Token). The internal
-reference rate is **1 RTC = $0.10 USD**. Payouts are transferred from the
+reference rate is **1 RTC = $0.15 USD** (live rate at
+https://rustchain.org/api/tokenomics). Payouts are transferred from the
 `founder_team_bounty` wallet to your personal wallet after your
 contribution is reviewed and merged.
 
@@ -144,10 +145,10 @@ or use `-k` with curl.
 
 | Tier | RTC Range | USD Equivalent | Typical Scope |
 |------|-----------|----------------|---------------|
-| Micro | 1 - 10 RTC | $0.10 - $1.00 | Docs fixes, repo stars, social media shares, typo corrections |
-| Standard | 10 - 50 RTC | $1.00 - $5.00 | Feature additions, integrations, test suites, API docs |
-| Major | 50 - 200 RTC | $5.00 - $20.00 | Architecture work, protocol implementations, dashboards |
-| Critical | 200 - 500 RTC | $20.00 - $50.00 | Security audits, consensus attacks, red-team challenges |
+| Micro | 1 - 10 RTC | $0.15 - $1.50 | Docs fixes, repo stars, social media shares, typo corrections |
+| Standard | 10 - 50 RTC | $1.50 - $7.50 | Feature additions, integrations, test suites, API docs |
+| Major | 50 - 200 RTC | $7.50 - $30.00 | Architecture work, protocol implementations, dashboards |
+| Critical | 200 - 500 RTC | $30.00 - $75.00 | Security audits, consensus attacks, red-team challenges |
 
 ---
 
@@ -209,29 +210,31 @@ The following will cause a submission to be rejected regardless of score:
 
 ---
 
-## wRTC Bridge (Coming Soon)
+## wRTC Bridge
 
-wRTC is an ERC-20 token on Base L2 that wraps RTC for use on public
-Ethereum infrastructure.
+wRTC is an SPL token on Solana that wraps RTC for use on public
+infrastructure. It is live and swappable, but liquidity is early-stage
+and thin; treat it as experimental.
 
 | Property | Value |
 |----------|-------|
-| Standard | ERC-20 |
-| Chain | Base L2 (Ethereum layer-2) |
+| Standard | SPL token (Solana) |
+| Chain | Solana |
 | Decimals | 6 |
 | Name | Wrapped RTC |
 | Symbol | wRTC |
 | Bridge type | Custodial (mint/burn) |
+| Token mint | `12TAdKXxcGf6oCv4rqDz2NkgxjyHq6HQKoxKZYGf5i4X` |
 
-**How the bridge will work:**
+**How the bridge works** (official bridge: https://bottube.ai/bridge/wrtc):
 
 1. **RTC to wRTC**: Lock RTC on the RustChain side. Bridge operator mints
-   equivalent wRTC on Base L2.
-2. **wRTC to RTC**: Burn wRTC on Base L2. Bridge operator releases
+   equivalent wRTC on Solana.
+2. **wRTC to RTC**: Burn wRTC on Solana. Bridge operator releases
    equivalent RTC on RustChain.
 
-The bridge is under active development. Until it launches, RTC lives
-entirely on the RustChain attestation chain.
+See the [wRTC Quickstart](https://github.com/Scottcjn/Rustchain/blob/main/docs/wrtc.md)
+for the anti-scam checklist and step-by-step instructions.
 
 ---
 

--- a/docs/PHILOSOPHY.md
+++ b/docs/PHILOSOPHY.md
@@ -162,12 +162,12 @@ We are not building for a token launch, an acquisition, or a hype cycle.
 **Our timeline is years, not quarters:**
 
 - **RTC is utility-first.** The token has value because it pays for real
-  work: bounties completed, agents coordinated, services rendered. We set
-  the reference rate at $0.10 because we want it to be useful today, not
-  speculative tomorrow.
-- **The wRTC bridge is deliberate.** We are building the ERC-20 bridge to
-  Base L2 carefully, not rushing it for DeFi liquidity. The attestation
-  chain must be rock-solid before we connect it to public markets.
+  work: bounties completed, agents coordinated, services rendered. We keep
+  the reference rate low ($0.15 today) because we want it to be useful
+  now, not speculative tomorrow.
+- **The wRTC bridge is deliberate.** The wRTC bridge to Solana is run
+  carefully, not rushed for DeFi liquidity. The attestation chain must be
+  rock-solid before we deepen exposure to public markets.
 - **Documentation is not an afterthought.** This entire `bounty-concierge`
   repo exists because we believe onboarding is as important as the code
   itself. If a contributor cannot understand the system, the system has

--- a/docs/TECH_STACK.md
+++ b/docs/TECH_STACK.md
@@ -38,7 +38,8 @@ hash power or stake size.
 - **Ergo Anchoring**: Periodic on-chain anchors to a private Ergo chain.
   Miner attestation commitments are stored in Ergo box registers (R4-R9)
   as Blake2b256 hashes.
-- **Token**: RTC (RustChain Token). Internal reference rate: 1 RTC = $0.10 USD.
+- **Token**: RTC (RustChain Token). Internal reference rate: 1 RTC = $0.15 USD
+  (live rate at https://rustchain.org/api/tokenomics).
 - **Genesis**: Production chain launched December 2, 2025.
   (`GENESIS_TIMESTAMP = 1764706927`)
 
@@ -220,38 +221,33 @@ in the Atlas directory.
 
 ## wRTC Bridge
 
-wRTC (wrapped RTC) is an ERC-20 token on Base L2 that represents RTC on
-a public blockchain, enabling DeFi and trading.
+wRTC (wrapped RTC) is the Solana representation of RTC, enabling DeFi and
+trading. It is live and swappable, but liquidity is early-stage and thin;
+treat it as experimental, not a deep market.
 
 ### Token Specification
 
 | Property | Value |
 |----------|-------|
-| Standard | ERC-20 |
-| Chain | Base L2 (Ethereum L2) |
+| Standard | SPL token (Solana) |
+| Chain | Solana |
 | Decimals | 6 |
 | Name | Wrapped RTC |
 | Symbol | wRTC |
+| Token mint | `12TAdKXxcGf6oCv4rqDz2NkgxjyHq6HQKoxKZYGf5i4X` |
 
 ### Bridge Mechanism
 
-The bridge is custodial (mint/burn model):
+The bridge is custodial (mint/burn model), operated at
+https://bottube.ai/bridge/wrtc:
 
 1. **RTC to wRTC**: User locks RTC on the RustChain side. Bridge operator
-   mints equivalent wRTC on Base L2.
-2. **wRTC to RTC**: User burns wRTC on Base L2. Bridge operator releases
+   mints equivalent wRTC on Solana.
+2. **wRTC to RTC**: User burns wRTC on Solana. Bridge operator releases
    equivalent RTC on RustChain.
 
-### Smart Contract
-
-```solidity
-contract WrappedRTC is ERC20, Ownable {
-    // Mint: only bridge operator
-    function mint(address to, uint256 amount) external onlyOwner;
-    // Burn: any holder
-    function burn(uint256 amount) external;
-}
-```
+Full details, including the anti-scam checklist, are in the
+[wRTC Quickstart](https://github.com/Scottcjn/Rustchain/blob/main/docs/wrtc.md).
 
 ---
 

--- a/tests/test_announcer.py
+++ b/tests/test_announcer.py
@@ -65,7 +65,7 @@ class TestFormatAnnouncement:
 
         assert "| Title | RTC | Difficulty | Link |" in result["long"]
         assert "| Python tests | 2 | standard | [link](https://example.test/2) |" in result["long"]
-        assert "1 RTC = $0.10 USD" in result["long"]
+        assert "1 RTC = $0.15 USD" in result["long"]
 
     def test_missing_optional_fields_use_placeholders(self):
         result = announcer.format_announcement([{"title": "No metadata"}])

--- a/tests/test_faq_engine.py
+++ b/tests/test_faq_engine.py
@@ -48,7 +48,7 @@ class TestFuzzyMatch:
     def test_rtc_reward_parsing(self):
         """FAQ should contain RTC value info."""
         key, answer, score = faq_engine.fuzzy_match("what is rtc")
-        assert "$0.10" in answer or "0.10" in answer
+        assert "$0.15" in answer or "0.15" in answer
 
     def test_payout_faq(self):
         """Payout FAQ should mention PR merge."""
@@ -56,9 +56,10 @@ class TestFuzzyMatch:
         assert answer is not None
 
     def test_wrtc_faq(self):
-        """WRTC FAQ should mention Ergo blockchain."""
+        """WRTC FAQ should mention Solana."""
         key, answer, score = faq_engine.fuzzy_match("what is wrtc")
         assert answer is not None
+        assert "Solana" in answer
 
     def test_proof_of_antiquity_faq(self):
         """PoA FAQ should mention multipliers."""


### PR DESCRIPTION
Two factual corrections, verified against the most authoritative sources I could find on 2026-07-25.

Reference rate:
- This repo said 1 RTC = $0.10 USD in the README, three docs, the FAQ engine, and the announcer. The live https://rustchain.org/api/tokenomics reports 1,528 holders, past the 1,000-holder milestone that moves the rate to $0.15, and the main Rustchain README states $0.15. All occurrences updated, and the USD columns in the bounty tier tables recomputed at the new rate. Where it made sense the text now links the live endpoint so it ages better.

wRTC chain:
- Sources disagreed three ways: this repo's docs said Base L2 (ERC-20), the FAQ engine said Ergo, and the main Rustchain repo says Solana. The main repo wins: its README section "wRTC on Solana" and docs/wrtc.md give a live SPL token (mint `12TAdKXxcGf6oCv4rqDz2NkgxjyHq6HQKoxKZYGf5i4X`, 6 decimals) and the bridge at https://bottube.ai/bridge/wrtc returns 200. The Ergo and Base L2 claims appear to be older design iterations. Everything here now says Solana and links the main repo's quickstart, with the honest thin-liquidity caveat carried over.
- Also fixed "RTC is not yet traded on any exchange" and "the bridge is under development and not yet live", both now false.

Tests updated to match; `pytest` passes 227/227.