### PR TITLE
fix: working build backend, GitHub install docs, drop clawrtc collision

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,9 @@ For a deep dive, see [docs/TECH_STACK.md](docs/TECH_STACK.md).
 ### Installation
 
 ```bash
-pip install bounty-concierge
+pip install git+https://github.com/Scottcjn/bounty-concierge.git
+
+> **Note:** PyPI publication is pending. Install directly from GitHub for now.
 ```
 
 ### Usage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = ["setuptools>=82.0.1"]
-build-backend = "setuptools.backends._legacy:_Backend"
+build-backend = "setuptools.build_meta"
 
 [project]
 name = "bounty-concierge"
@@ -13,4 +13,6 @@ dependencies = ["requests>=2.32.5"]
 
 [project.scripts]
 concierge = "concierge.cli:main"
-clawrtc = "concierge.cli:main"
+
+[tool.setuptools.packages.find]
+include = ["concierge*"]


### PR DESCRIPTION
## Fixes #46

### Changes
- **pyproject.toml**: Replaced non-existent `setuptools.backends._legacy:_Backend` with standard `setuptools.build_meta`
- **pyproject.toml**: Removed `clawrtc` console script alias that shadowed the real Rust `clawrtc` binary
- **pyproject.toml**: Added `[tool.setuptools.packages.find]` with `include = ["concierge*"]`
- **README.md**: Updated install instructions to use git URL
- **README.md**: Added PyPI-pending note

### Bounty
Wallet: `leanworld7` (registration #49)