### PR TITLE
docs: remove stale bounty totals from onboarding docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ RustChain is a blockchain that rewards real hardware -- especially vintage machi
 | Repo | Issue | Title | RTC | Difficulty | Skills |
 |------|-------|-------|-----|------------|--------|
 <!-- BOUNTY-TABLE-START -->
-_Showing top 10 of 124 open bounties, sorted by RTC reward. Index rebuilt 2026-07-25T08:17:50.849958+00:00._
+_Showing top 10 open bounties, sorted by RTC reward. Index rebuilt 2026-08-13T07:44:21.043315+00:00. For the live total, use the full bounty board link above._
 
 | Repo | Issue | Title | RTC | Difficulty | Skills |
 |------|-------|-------|-----|------------|--------|
@@ -51,18 +51,6 @@ _Showing top 10 of 124 open bounties, sorted by RTC reward. Index rebuilt 2026-0
 | rustchain-bounties | [#2819](https://github.com/Scottcjn/rustchain-bounties/issues/2819) | [BOUNTY] Red Team UTXO Implementation — Find Bugs, Earn R... | 133 | major | documentation, javascript, python, rust, security |
 | rustchain-bounties | [#3418](https://github.com/Scottcjn/rustchain-bounties/issues/3418) | [BOUNTY] Register on Beacon Atlas + Prove Commerce (Pool:... | 100 | major | documentation, javascript, python, rust, security, social-media |
 <!-- BOUNTY-TABLE-END -->
-| rustchain-bounties | [#491](https://github.com/Scottcjn/rustchain-bounties/issues/491) | RIP-201 Fleet Detection Bypass | 200 | Major | Security, Python, Consensus |
-| rustchain-bounties | [#492](https://github.com/Scottcjn/rustchain-bounties/issues/492) | RIP-201 Bucket Normalization Gaming | 150 | Standard | Security, Math |
-| rustchain-bounties | [#475](https://github.com/Scottcjn/rustchain-bounties/issues/475) | Attestation Fuzz Harness + Crash Regression | 98 | Standard | Fuzzing, Python |
-| rustchain-bounties | [#501](https://github.com/Scottcjn/rustchain-bounties/issues/501) | Miner Dashboard -- Personal Stats & History | 75 | Standard | Frontend, API |
-| rustchain-bounties | [#505](https://github.com/Scottcjn/rustchain-bounties/issues/505) | Hall of Fame Machine Detail Pages | 50 | Standard | Frontend, HTML/CSS |
-| rustchain-bounties | [#504](https://github.com/Scottcjn/rustchain-bounties/issues/504) | Prometheus Metrics Exporter + Grafana | 40 | Standard | DevOps, Monitoring |
-| rustchain-bounties | [#502](https://github.com/Scottcjn/rustchain-bounties/issues/502) | OpenAPI/Swagger Documentation | 30 | Standard | API, Documentation |
-| rustchain-bounties | [#473](https://github.com/Scottcjn/rustchain-bounties/issues/473) | Dual-Mining: Scala (RandomX) Integration | 10 | Standard | Cryptography, Python |
-| rustchain-bounties | [#507](https://github.com/Scottcjn/rustchain-bounties/issues/507) | Upvote RustChain on SaaSCity | 10 | Micro | Community |
-| rustchain-bounties | [#518](https://github.com/Scottcjn/rustchain-bounties/issues/518) | First Blood -- First Merged PR | 3 | Micro | Any |
-| rustchain-bounties | [#512](https://github.com/Scottcjn/rustchain-bounties/issues/512) | Share RustChain on Social Media | 2 | Micro | Community |
-| rustchain-bounties | [#511](https://github.com/Scottcjn/rustchain-bounties/issues/511) | Star 5+ Repos Challenge | 2 | Micro | Community |
 
 Open bounty totals change frequently. See the [live full list](https://github.com/Scottcjn/rustchain-bounties/issues?q=is%3Aopen+label%3Abounty) for the current count.
 

--- a/concierge/readme_sync.py
+++ b/concierge/readme_sync.py
@@ -84,12 +84,11 @@ def build_section(top_n: int = DEFAULT_TOP_N) -> str:
     """
     payload = json.loads(INDEX_PATH.read_text())
     bounties = payload.get("bounties") or []
-    total = payload.get("total_count", len(bounties))
     updated = payload.get("updated_at", "unknown")
     table = render_table(bounties, top_n=top_n)
     header = (
-        f"_Showing top {min(top_n, len(bounties))} of {total} open bounties, "
-        f"sorted by RTC reward. Index rebuilt {updated}._"
+        f"_Showing top {min(top_n, len(bounties))} open bounties, "
+        f"sorted by RTC reward. Index rebuilt {updated}. For the live total, use the full bounty board link above._"
     )
     return f"{header}\n\n{table}"
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -389,7 +389,7 @@ Dev.to, or SaaSCity. Check the individual issue for exact requirements.
 | Repository | Description |
 |------------|-------------|
 | [RustChain](https://github.com/Scottcjn/Rustchain) | Core blockchain node with RIP-200/201 consensus |
-| [rustchain-bounties](https://github.com/Scottcjn/rustchain-bounties) | Bounty board with 154+ open tasks |
+| [rustchain-bounties](https://github.com/Scottcjn/rustchain-bounties) | Live bounty board for current open tasks |
 | [bottube](https://github.com/Scottcjn/bottube) | AI video platform with Python SDK (`pip install bottube`) |
 | [beacon-skill](https://github.com/Scottcjn/beacon-skill) | Agent-to-agent coordination protocol |
 | [ram-coffers](https://github.com/Scottcjn/ram-coffers) | NUMA-distributed weight banking for LLM inference |

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -144,7 +144,7 @@ and has its own bounty issues:
 
 | Repository | Language | Description |
 |------------|----------|-------------|
-| [rustchain-bounties](https://github.com/Scottcjn/rustchain-bounties) | -- | Bounty board with 154+ open tasks (file claims here) |
+| [rustchain-bounties](https://github.com/Scottcjn/rustchain-bounties) | -- | Live bounty board for current open tasks (file claims here) |
 | [RustChain](https://github.com/Scottcjn/Rustchain) | Python | Core blockchain node -- RIP-200/201 consensus, attestation |
 | [bottube](https://github.com/Scottcjn/bottube) | Python | AI video platform, Python SDK (`pip install bottube`) |
 | [beacon-skill](https://github.com/Scottcjn/beacon-skill) | Python | Agent-to-agent coordination protocol |

--- a/tests/test_readme_sync.py
+++ b/tests/test_readme_sync.py
@@ -96,7 +96,7 @@ def test_build_section_reads_real_index_file():
             "bounties": SAMPLE_BOUNTIES,
         }))
     section = rs.build_section(top_n=3)
-    assert "open bounties" in section
+    assert "Showing top 3 open bounties" in section
     # At least one row with a number link present
     assert "[#" in section and "](https://" in section  # markdown issue link
 


### PR DESCRIPTION
## Summary
- remove hard-coded open-bounty totals from onboarding docs
- make the README sync header point readers to the live board instead of embedding a stale total
- drop the stale legacy table rows left below the generated README section

## Testing
- `pytest -q tests/test_readme_sync.py tests/test_faq_engine.py`
- `python3 -m concierge.readme_sync`

Closes #39
