### PR TITLE
[Codex] Run the README bounty refresh and preserve literal titles

### DIFF
--- a/.github/workflows/bounty_index_sync.yml
+++ b/.github/workflows/bounty_index_sync.yml
@@ -28,8 +28,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: python -m concierge.bounty_index > data/bounty_index.json
 
-      - name: Auto-commit updated index
+      - name: Refresh README Open Bounties table
+        run: python -m concierge.readme_sync
+
+      - name: Auto-commit updated index and README
         uses: stefanzweifel/git-auto-commit-action@v7
         with:
-          commit_message: "chore: update bounty index [automated]"
-          file_pattern: data/bounty_index.json
+          commit_message: "chore: update bounty index and README [automated]"
+          file_pattern: data/bounty_index.json README.md

--- a/concierge/readme_sync.py
+++ b/concierge/readme_sync.py
@@ -110,7 +110,7 @@ def update_readme(readme_text: str, section: str) -> str:
             "Add them around the Open Bounties table."
         )
     new_block = f"{START_MARKER}\n{section}\n{END_MARKER}"
-    return pattern.sub(new_block, readme_text)
+    return pattern.sub(lambda _match: new_block, readme_text)
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/tests/test_readme_sync_literals.py
+++ b/tests/test_readme_sync_literals.py
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: MIT
+"""README refresh must preserve generated text without regex substitution."""
+import json
+
+import pytest
+
+from concierge import readme_sync
+
+
+@pytest.mark.parametrize("title", [r"Windows C:\tools\new build", r"Document regex \g<1>"])
+def test_main_preserves_title_backslashes_and_is_idempotent(title, tmp_path, monkeypatch):
+    index_path = tmp_path / "bounty_index.json"
+    readme_path = tmp_path / "README.md"
+    index_path.write_text(json.dumps({
+        "updated_at": "2026-09-08T00:00:00Z",
+        "bounties": [{
+            "repo": "example/project",
+            "number": 1,
+            "title": title,
+            "reward_rtc": 10,
+            "skills": ["documentation"],
+        }],
+    }))
+    readme_path.write_text(
+        "Intro\n" + readme_sync.START_MARKER + "\nOld table\n"
+        + readme_sync.END_MARKER + "\nFooter\n"
+    )
+    monkeypatch.setattr(readme_sync, "INDEX_PATH", index_path)
+    monkeypatch.setattr(readme_sync, "README_PATH", readme_path)
+
+    assert readme_sync.main([]) == 0
+    updated = readme_path.read_text()
+    assert title in updated
+    assert "Old table" not in updated
+    assert updated.startswith("Intro\n") and updated.endswith("\nFooter\n")
+    assert readme_sync.main([]) == 0
+    assert readme_path.read_text() == updated


### PR DESCRIPTION
The merged README generator from #45 was not yet invoked by the scheduled index workflow. Add that invocation after rebuilding the index and include README.md in the existing automatic commit. Preserve literal generated text during sentinel replacement so titles containing Windows paths or regex backreferences do not get rewritten.

This follows up on #45's documented workflow omission and retains its existing generator. Validation: the full suite passes 232 tests and all 8 focused README tests pass. Both new regressions fail against the original replacement implementation (2 failed) and now verify exact title preservation, surrounding content, and repeat-run idempotence. The workflow wiring was inspected locally; its next hosted execution remains unverified.

Prepared with Codex. Related improvement program: Scottcjn/rustchain-bounties#100.