### PR TITLE
[Codex] Preserve common CLI flags across subcommands

### DIFF
--- a/concierge/cli.py
+++ b/concierge/cli.py
@@ -864,13 +864,13 @@ def _add_common_flags(parser):
     parser.add_argument(
         "--dry-run",
         action="store_true",
-        default=False,
+        default=argparse.SUPPRESS,
         help="Preview actions without making network calls",
     )
     parser.add_argument(
         "--json",
         action="store_true",
-        default=False,
+        default=argparse.SUPPRESS,
         help="Output results as JSON",
     )
 
@@ -882,6 +882,8 @@ def _build_parser():
         description="RustChain Bounty Concierge -- CLI for bounty hunters",
     )
     _add_common_flags(parser)
+    # Subparsers must not replace common flags supplied before their command.
+    parser.set_defaults(dry_run=False, json=False)
 
     sub = parser.add_subparsers(dest="command", help="Available commands")
 

--- a/tests/test_cli_common_flags.py
+++ b/tests/test_cli_common_flags.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: MIT
+"""Global output and preview flags survive subcommand parsing."""
+import json
+import sys
+
+import pytest
+
+from concierge import cli
+
+
+@pytest.mark.parametrize("argv", [
+    ["--json", "browse"],
+    ["browse", "--json"],
+])
+def test_browse_json_flag_works_before_or_after_command(argv, monkeypatch, capsys):
+    bounty = {
+        "repo": "example/project", "number": 1, "title": "Python task",
+        "reward_rtc": 10, "difficulty": "standard", "skills": ["python"],
+    }
+    monkeypatch.setattr(cli, "fetch_bounties", lambda **kwargs: [bounty])
+    monkeypatch.setattr(sys, "argv", ["concierge", *argv])
+    cli.main()
+    assert json.loads(capsys.readouterr().out) == [bounty]
+
+
+@pytest.mark.parametrize("argv", [
+    ["--dry-run", "browse"],
+    ["browse", "--dry-run"],
+])
+def test_browse_preview_does_not_fetch_in_either_position(argv, monkeypatch, capsys):
+    calls = []
+    monkeypatch.setattr(cli, "fetch_bounties", lambda **kwargs: calls.append(kwargs) or [])
+    monkeypatch.setattr(sys, "argv", ["concierge", *argv])
+    cli.main()
+    assert calls == []
+    assert "[dry-run]" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize("argv", [
+    ["--json", "--dry-run", "wallet", "balance", "example"],
+    ["wallet", "--json", "--dry-run", "balance", "example"],
+    ["wallet", "balance", "example", "--json", "--dry-run"],
+])
+def test_nested_parser_preserves_flags_at_each_level(argv):
+    args = cli._build_parser().parse_args(argv)
+    assert args.json is True
+    assert args.dry_run is True
+
+
+def test_flags_default_to_false_without_leaking_between_parses():
+    parser = cli._build_parser()
+    parser.parse_args(["--json", "--dry-run", "browse"])
+    args = parser.parse_args(["wallet", "balance", "example"])
+    assert args.json is False
+    assert args.dry_run is False


### PR DESCRIPTION
Subparser defaults reset `--json` and `--dry-run` when those options appeared before a command or nested wallet action. Suppress defaults on each common flag definition and set the false defaults once at the root parser, so options retain their meaning in every supported position.

Validation: the full suite passes 238 tests and all 8 new regressions pass; four fail against the original parser (4 failed, 4 passed). Tests exercise JSON output and preview behavior through the browse command, flag placement at all three wallet command levels, and clean defaults when the same parser is reused. Network functions are mocked; no wallet operations are executed. The full run has one unchanged test escape-sequence warning.

Prepared with Codex. Related improvement program: Scottcjn/rustchain-bounties#100.